### PR TITLE
Fix factor 16 angle business.

### DIFF
--- a/src/GRSim.cpp
+++ b/src/GRSim.cpp
@@ -363,6 +363,7 @@ void addRobotCommandToPacket(grSim_Packet & packet, roboteam_msgs::RobotCommand 
     // geneva_angle in radians
     float geneva_angle = 2 * M_PI * angles[index] / 360;
     command->set_geneva_angle(geneva_angle);
+    command->set_use_angle(msg.use_angle);
 }
 
 }

--- a/src/packing.cpp
+++ b/src/packing.cpp
@@ -51,7 +51,11 @@ namespace rtt {
         llrc.driving_reference  = false;                                           // [0, 1]          {true, false}
         llrc.use_cam_info       = false;                                           // [0, 1]          {true, false}
         llrc.use_angle          = command.use_angle;                               // [0, 1]          {true, false}
-        llrc.velocity_angular   = (int)floor(command.w * (511 / (8 * 2*M_PI)));    // [-512, 511]     [-8*2pi, 8*2pi]
+        if(command.use_angle){
+            llrc.velocity_angular   = (int)floor(command.w * (511 / M_PI));        // [-512, 511]     [-pi, pi]
+        }else{
+            llrc.velocity_angular   = (int)floor(command.w * (511 / (8 * 2*M_PI)));// [-512, 511]     [-8*2pi, 8*2pi]
+        }
         llrc.debug_info         = true;                                            // [0, 1]          {true, false}
         llrc.do_kick            = command.kicker;                                  // [0, 1]          {true, false}
         llrc.do_chip            = command.chipper;                                 // [0, 1]          {true, false}


### PR DESCRIPTION
This fixes the problem with the factor 16 not working well. Now if use_angle is set, we set the angle of the robot, and otherwise the angular velocity, without having to scale by a factor 16 anywhere.