### PR TITLE
MacOS support and build improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,17 +6,9 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
 
 set(CMAKE_CXX_FLAGS "-std=c++17 ${CMAKE_CXX_FLAGS} -O3")
 
-# for MacOS X or iOS, watchOS, tvOS (since 3.10.3)
-if(APPLE)
-    set(Qt5Network_DIR "/usr/local/opt/qt/lib/cmake/Qt5Network")
-endif()
+include(LocateQt5)
 
-# for Linux, BSD, Solaris, Minix
-if(UNIX AND NOT APPLE)
-    SET(Qt5Network_DIR "/usr/include/x86_64-linux-gnu/qt5/Qt5Network")
-endif()
-
-find_package(Qt5Network REQUIRED)
+find_package(Qt5 COMPONENTS Network REQUIRED)
 
 add_executable(roboteam_robothub
         src/packing.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,5 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 project(roboteam_robothub)
-
-# Needed for the documentation generator.
-set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
-
-set(CMAKE_CXX_FLAGS "-std=c++17 ${CMAKE_CXX_FLAGS} -O3")
-
-include(LocateQt5)
 
 find_package(Qt5 COMPONENTS Network REQUIRED)
 
@@ -15,16 +8,18 @@ add_executable(roboteam_robothub
         src/GRSim.cpp
         src/SerialDeviceManager.cpp
         src/RobotHub.cpp
-        src/main.cpp src/SSLSimulator.cpp include/roboteam_robothub/SSLSimulator.h)
+        src/main.cpp
+        src/SSLSimulator.cpp
+        )
 
 
 target_include_directories(roboteam_robothub
-        INTERFACE include
         PRIVATE include/roboteam_robothub
-        PRIVATE src )
+        INTERFACE include
+        )
 
 target_link_libraries(roboteam_robothub
-        PUBLIC roboteam_proto
+        PRIVATE roboteam_proto
         PRIVATE roboteam_utils
         PRIVATE Qt5::Network
         )

--- a/include/roboteam_robothub/RobotHub.h
+++ b/include/roboteam_robothub/RobotHub.h
@@ -5,16 +5,17 @@
 #ifndef ROBOTEAM_ROBOTHUB_APPLICATION_H
 #define ROBOTEAM_ROBOTHUB_APPLICATION_H
 
-#include <Publisher.h>
-#include <Subscriber.h>
-#include <string>
-#include <roboteam_proto/RobotData.pb.h>
+#include <networking/Publisher.h>
+#include <networking/Subscriber.h>
 #include <roboteam_proto/AICommand.pb.h>
+#include <roboteam_proto/RobotData.pb.h>
 #include <roboteam_proto/Setting.pb.h>
 
+#include <string>
+
+#include "SSLSimulator.h"
 #include "constants.h"
 #include "utilities.h"
-#include "SSLSimulator.h"
 
 namespace rtt::robothub {
 


### PR DESCRIPTION
This was supposed to be just a quick job of adding MacOS support, but I noticed a couple of things that could be improved with the build system.

- Refactor to use modern CMake
- Work around Qt5 issues on MacOS
- Add instructions on how to build on MacOS
- Add missing and remove redundant dependencies in README
- Add CCache install instructions to README
- Set CMake to use unity builds
- Remove unused CMake files (cotire was included but not actually used)
  - Use modern CMake features to speed up build times
- Recommend and set default build system to Ninja
- Use newer method of fetching/discovering dependencies
   - Remove unnecessary third party git submodules 
- Change structure of some roboteam repositories (e.g. where full CMake projects were nested in the `include/` directory)


Only meant to be merged together with corresponding PRs in other repos.