### PR TITLE
Fix the code style of all roboteam files

### DIFF
--- a/include/roboteam_robothub/RobotHub.h
+++ b/include/roboteam_robothub/RobotHub.h
@@ -54,7 +54,7 @@ class RobotHub {
 
     void processAIBatch(proto::AICommand &cmd);
     void sendSimulatorBatch(proto::AICommand &cmd, const proto::World &world);
-    bool processCommand(const proto::RobotCommand &robotCommand,const proto::World& world);
+    bool processCommand(const proto::RobotCommand &robotCommand, const proto::World &world);
     void processSettings(proto::Setting &setting);
 
     // Serial and grsim managers
@@ -70,6 +70,6 @@ class RobotHub {
     std::mutex worldLock;
 };
 
-}  // namespace rtt
+}  // namespace rtt::robothub
 
 #endif  // ROBOTEAM_ROBOTHUB_APPLICATION_H

--- a/include/roboteam_robothub/SSLSimulator.h
+++ b/include/roboteam_robothub/SSLSimulator.h
@@ -6,25 +6,25 @@
 #define RTT_SSLSIMULATOR_H
 
 #include <roboteam_proto/RobotCommand.pb.h>
-#include <roboteam_proto/ssl_simulation_robot_control.pb.h>
-#include <QUdpSocket>
 #include <roboteam_proto/World.pb.h>
+#include <roboteam_proto/ssl_simulation_robot_control.pb.h>
+
+#include <QUdpSocket>
 
 class SSLSimulator {
-public:
+   public:
     void set_ip(std::string ip);
     void set_color(bool is_yellow);
     void add_robot_command(const proto::RobotCommand& command, const proto::World& world);
     void send_commands();
-    [[nodiscard]] proto::sim::RobotCommand convert_command(const proto::RobotCommand& command,const proto::World& world) const;
-private:
+    [[nodiscard]] proto::sim::RobotCommand convert_command(const proto::RobotCommand& command, const proto::World& world) const;
+
+   private:
     std::vector<proto::sim::RobotCommand> commands;
     QUdpSocket socket;
     std::string ip;
     quint16 port;
     bool is_yellow;
-
 };
 
-
-#endif //RTT_SSLSIMULATOR_H
+#endif  // RTT_SSLSIMULATOR_H

--- a/include/roboteam_robothub/SerialDeviceManager.h
+++ b/include/roboteam_robothub/SerialDeviceManager.h
@@ -6,6 +6,7 @@
 #define ROBOTEAM_ROBOTHUB_SERIALDEVICEMANAGER_H
 
 #include <fstream>
+
 #include "packing.h"
 
 namespace rtt {

--- a/include/roboteam_robothub/packing.h
+++ b/include/roboteam_robothub/packing.h
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <iostream>
 #include <string>
+
 #include "roboteam_proto/RobotCommand.pb.h"
 #include "roboteam_proto/RobotFeedback.pb.h"
 #include "roboteam_proto/World.pb.h"

--- a/include/roboteam_robothub/utilities.h
+++ b/include/roboteam_robothub/utilities.h
@@ -8,6 +8,7 @@
 #include <bitset>
 #include <iostream>
 #include <string>
+
 #include "packing.h"
 #include "roboteam_proto/World.pb.h"
 
@@ -15,7 +16,7 @@ namespace rtt {
 namespace robothub {
 namespace utils {
 
-enum class Mode { SERIAL, GRSIM, UNDEFINED,SSL_SIMULATOR };
+enum class Mode { SERIAL, GRSIM, UNDEFINED, SSL_SIMULATOR };
 
 static int char2int(char input) {
     if (input >= '0' && input <= '9') return input - '0';

--- a/src/GRSim.cpp
+++ b/src/GRSim.cpp
@@ -1,5 +1,7 @@
 #include "GRSim.h"
+
 #include <numeric>
+
 #include "packing.h"
 #include "roboteam_utils/Vector2.h"
 
@@ -307,7 +309,6 @@ void addRobotCommandToPacket(proto::grSim_Packet& packet, proto::RobotCommand co
 
     command->set_spinner((msg.dribbler() > 0));
     command->set_use_angle(msg.use_angle());
-
 }
 
 }  // namespace robothub

--- a/src/RobotHub.cpp
+++ b/src/RobotHub.cpp
@@ -1,11 +1,12 @@
 
+#include "RobotHub.h"
+
 #include <roboteam_utils/Timer.h>
-#include "roboteam_proto/Setting.pb.h"
 
 #include "GRSim.h"
-#include "RobotHub.h"
 #include "SerialDeviceManager.h"
 #include "packing.h"
+#include "roboteam_proto/Setting.pb.h"
 
 namespace rtt::robothub {
 
@@ -57,25 +58,24 @@ void RobotHub::printStatistics() {
 }
 
 void RobotHub::processAIBatch(proto::AICommand &cmd) {
-  //TODO split up sending here, not in the lower functions
-  if( mode == utils::Mode::SSL_SIMULATOR){
-      sendSimulatorBatch(cmd,cmd.extrapolatedworld());
-      return;
-  }
-  proto::RobotData sentCommands;
-  sentCommands.set_isyellow(isYellow);
-  for(const auto& command : cmd.commands()){
-    bool wasSent =processCommand(command,cmd.extrapolatedworld());
-    if(wasSent){
-      proto::RobotCommand * sent = sentCommands.mutable_sentcommands()->Add();
-      sent->CopyFrom(command);
+    // TODO split up sending here, not in the lower functions
+    if (mode == utils::Mode::SSL_SIMULATOR) {
+        sendSimulatorBatch(cmd, cmd.extrapolatedworld());
+        return;
     }
-  }
-  //TODO: add times command was sent
-  feedbackPublisher->send(sentCommands);
-
+    proto::RobotData sentCommands;
+    sentCommands.set_isyellow(isYellow);
+    for (const auto &command : cmd.commands()) {
+        bool wasSent = processCommand(command, cmd.extrapolatedworld());
+        if (wasSent) {
+            proto::RobotCommand *sent = sentCommands.mutable_sentcommands()->Add();
+            sent->CopyFrom(command);
+        }
+    }
+    // TODO: add times command was sent
+    feedbackPublisher->send(sentCommands);
 }
-bool RobotHub::processCommand(const proto::RobotCommand &robotCommand,const proto::World &world) {
+bool RobotHub::processCommand(const proto::RobotCommand &robotCommand, const proto::World &world) {
     LowLevelRobotCommand llrc = createLowLevelRobotCommand(robotCommand, world, isYellow);
 
     // check if the command is valid, otherwise don't send anything
@@ -119,14 +119,14 @@ bool RobotHub::sendSerialCommand(LowLevelRobotCommand llrc) {
 
 /// send a GRSim command from a given robotcommand
 bool RobotHub::sendGrSimCommand(const proto::RobotCommand &robotCommand) {
-  this->grsimCommander->queueGRSimCommand(robotCommand);
-  return true;
+    this->grsimCommander->queueGRSimCommand(robotCommand);
+    return true;
 }
 
 void RobotHub::publishRobotFeedback(LowLevelRobotFeedback llrf) {
     if (llrf.id >= 0 && llrf.id < 16) {
         proto::RobotData data;
-        proto::RobotFeedback * feedback = data.mutable_receivedfeedback()->Add();
+        proto::RobotFeedback *feedback = data.mutable_receivedfeedback()->Add();
         feedback->CopyFrom(toRobotFeedback(llrf));
         data.set_isyellow(isYellow);
         feedbackPublisher->send(data);
@@ -145,7 +145,7 @@ void RobotHub::processSettings(proto::Setting &setting) {
     if (setting.serialmode()) {
         mode = utils::Mode::SERIAL;
     } else {
-        //mode = utils::Mode::GRSIM; //TODO; quick hack, make sure these can coexist, but need to fix this in AI and other places as well (bad idea for now)
+        // mode = utils::Mode::GRSIM; //TODO; quick hack, make sure these can coexist, but need to fix this in AI and other places as well (bad idea for now)
         mode = utils::Mode::SSL_SIMULATOR;
     }
 }
@@ -153,10 +153,10 @@ void RobotHub::set_robot_command_channel(const proto::ChannelType &robot_command
 void RobotHub::set_feedback_channel(const proto::ChannelType &feedback_channel) { feedbackChannel = feedback_channel; }
 void RobotHub::set_settings_channel(const proto::ChannelType &settings_channel) { settingsChannel = settings_channel; }
 
-void RobotHub::sendSimulatorBatch(proto::AICommand &cmd,const proto::World &world) {
+void RobotHub::sendSimulatorBatch(proto::AICommand &cmd, const proto::World &world) {
     proto::RobotData sentCommands;
     sentCommands.set_isyellow(isYellow);
-    for(const auto& command : cmd.commands()){
+    for (const auto &command : cmd.commands()) {
         LowLevelRobotCommand llrc = createLowLevelRobotCommand(command, cmd.extrapolatedworld(), isYellow);
 
         // check if the command is valid, otherwise don't send anything
@@ -166,10 +166,10 @@ void RobotHub::sendSimulatorBatch(proto::AICommand &cmd,const proto::World &worl
                       << std::endl;
             printLowLevelRobotCommand(llrc);
 
-        }else{
-            simulator_connection->add_robot_command(command,world);
+        } else {
+            simulator_connection->add_robot_command(command, world);
             robotTicks[command.id()]++;
-            proto::RobotCommand * sent = sentCommands.mutable_sentcommands()->Add();
+            proto::RobotCommand *sent = sentCommands.mutable_sentcommands()->Add();
             sent->CopyFrom(command);
         }
     }
@@ -177,4 +177,4 @@ void RobotHub::sendSimulatorBatch(proto::AICommand &cmd,const proto::World &worl
     feedbackPublisher->send(sentCommands);
 }
 
-}  // namespace rtt
+}  // namespace rtt::robothub

--- a/src/SSLSimulator.cpp
+++ b/src/SSLSimulator.cpp
@@ -3,46 +3,46 @@
 //
 
 #include "SSLSimulator.h"
+
+#include <roboteam_proto/World.pb.h>
 #include <roboteam_proto/ssl_simulation_robot_control.pb.h>
 #include <roboteam_proto/ssl_simulation_robot_feedback.pb.h>
-#include <roboteam_proto/World.pb.h>
-#include "utilities.h"
+
 #include <cmath>
 
+#include "utilities.h"
 
-proto::sim::RobotCommand SSLSimulator::convert_command(const proto::RobotCommand &command,const proto::World& world) const {
+proto::sim::RobotCommand SSLSimulator::convert_command(const proto::RobotCommand& command, const proto::World& world) const {
     proto::sim::RobotCommand sim_command;
     sim_command.set_id(command.id());
 
-
-    float kick_vel = command.chipper() || command.kicker() ?  command.chip_kick_vel() : 0.0f;
+    float kick_vel = command.chipper() || command.kicker() ? command.chip_kick_vel() : 0.0f;
     float kick_angle = command.chipper() ? 45.0f : 0.0f;
-    sim_command.set_kick_speed(kick_vel); //kick speed in m/s
+    sim_command.set_kick_speed(kick_vel);  // kick speed in m/s
     sim_command.set_kick_angle(kick_angle);
 
-    if(command.dribbler()>0){
-        sim_command.set_dribbler_speed(1021);//Theoretical max rpm according to alejandro, probably a bit quick..
-    }else{
+    if (command.dribbler() > 0) {
+        sim_command.set_dribbler_speed(1021);  // Theoretical max rpm according to alejandro, probably a bit quick..
+    } else {
         sim_command.set_dribbler_speed(0.0);
     }
     proto::sim::RobotMoveCommand move_command;
 
-    //below is for if erforce decides not to support global velocity. Above works fine in grsim... >.<
+    // below is for if erforce decides not to support global velocity. Above works fine in grsim... >.<
     {
         float robot_angle = 0.0;
-        std::shared_ptr<proto::WorldRobot> findBot = rtt::robothub::utils::getWorldBot(command.id(),is_yellow, world);
-        if(findBot){
-            robot_angle = - findBot->angle();
-        }else{
-            std::cout<<"could not find robot!"<<std::endl;
+        std::shared_ptr<proto::WorldRobot> findBot = rtt::robothub::utils::getWorldBot(command.id(), is_yellow, world);
+        if (findBot) {
+            robot_angle = -findBot->angle();
+        } else {
+            std::cout << "could not find robot!" << std::endl;
         }
         float forward = cosf(robot_angle) * command.vel().x() - sinf(robot_angle) * command.vel().y();
         float left = sinf(robot_angle) * command.vel().x() + cosf(robot_angle) * command.vel().y();
-        auto * local_vel = move_command.mutable_local_velocity();
+        auto* local_vel = move_command.mutable_local_velocity();
         local_vel->set_forward(forward);
         local_vel->set_left(left);
         local_vel->set_angular(command.w());
-
     }
 
     sim_command.mutable_move_command()->CopyFrom(move_command);
@@ -50,34 +50,25 @@ proto::sim::RobotCommand SSLSimulator::convert_command(const proto::RobotCommand
     return sim_command;
 }
 
-void SSLSimulator::set_ip(std::string _ip) {
-    ip = _ip;
-
-}
+void SSLSimulator::set_ip(std::string _ip) { ip = _ip; }
 
 void SSLSimulator::set_color(bool _is_yellow) {
     is_yellow = _is_yellow;
-    port = is_yellow ? 10302 : 10301; //TODO: hardcoded, make it settable?
+    port = is_yellow ? 10302 : 10301;  // TODO: hardcoded, make it settable?
 }
 
-void SSLSimulator::add_robot_command(const proto::RobotCommand &command, const proto::World& world) {
-    commands.push_back(convert_command(command,world));
-}
+void SSLSimulator::add_robot_command(const proto::RobotCommand& command, const proto::World& world) { commands.push_back(convert_command(command, world)); }
 
 void SSLSimulator::send_commands() {
-
     proto::sim::RobotControl packet;
-    for(const auto& command : commands){
+    for (const auto& command : commands) {
         packet.mutable_robot_commands()->Add()->CopyFrom(command);
     }
     QByteArray datagram;
     datagram.resize(packet.ByteSizeLong());
-    packet.SerializeToArray(datagram.data(),datagram.size());
+    packet.SerializeToArray(datagram.data(), datagram.size());
 
-    auto bytes_sent = socket.writeDatagram(datagram,QHostAddress(QString::fromStdString(ip)),port);
-
+    auto bytes_sent = socket.writeDatagram(datagram, QHostAddress(QString::fromStdString(ip)), port);
 
     commands.clear();
 }
-
-

--- a/src/SerialDeviceManager.cpp
+++ b/src/SerialDeviceManager.cpp
@@ -3,10 +3,13 @@
 //
 
 #include "SerialDeviceManager.h"
+
 #include <fcntl.h>
 #include <termios.h>
 #include <unistd.h>  // macOS wants this one
+
 #include <iostream>
+
 #include "utilities.h"
 
 namespace rtt {

--- a/src/packing.cpp
+++ b/src/packing.cpp
@@ -1,9 +1,11 @@
 #include "packing.h"
 
 #include <math.h>
+
 #include <cstdint>
 #include <iostream>
 #include <memory>
+
 #include "utilities.h"
 
 namespace rtt {
@@ -34,16 +36,16 @@ LowLevelRobotCommand createLowLevelRobotCommand(const proto::RobotCommand& comma
     } else {
         llrc.velocity_angular = static_cast<int>(floor(command.w() * (511 / (8 * 2 * M_PI))));  // [-512, 511]     [-8*2pi, 8*2pi]
     }
-    llrc.debug_info = true;                                                     // [0, 1]          {true, false}
-    llrc.do_kick = command.kicker();                                            // [0, 1]          {true, false}
-    llrc.do_chip = command.chipper();                                           // [0, 1]          {true, false}
-    llrc.kick_chip_forced = command.chip_kick_forced();                         // [0, 1] {true, false}
+    llrc.debug_info = true;                                                       // [0, 1]          {true, false}
+    llrc.do_kick = command.kicker();                                              // [0, 1]          {true, false}
+    llrc.do_chip = command.chipper();                                             // [0, 1]          {true, false}
+    llrc.kick_chip_forced = command.chip_kick_forced();                           // [0, 1] {true, false}
     llrc.kick_chip_power = static_cast<int>(floor(kick_chip_power * 255 / 6.5));  // [0, 255]        [0, 100]%
-    llrc.velocity_dribbler = command.dribbler();                                // [0, 31]        [0, 100]%
+    llrc.velocity_dribbler = command.dribbler();                                  // [0, 31]        [0, 100]%
 
-    llrc.cam_position_x = 0;                           // [-4096, 4095]   [-10.24, 10.23]
-    llrc.cam_position_y = 0;                           // [-4096, 4095]   [-10.24, 10.23]
-    llrc.cam_rotation = 0;                             // [-1024, 1023]   [-pi, pi>
+    llrc.cam_position_x = 0;  // [-4096, 4095]   [-10.24, 10.23]
+    llrc.cam_position_y = 0;  // [-4096, 4095]   [-10.24, 10.23]
+    llrc.cam_rotation = 0;    // [-1024, 1023]   [-pi, pi>
 
     std::shared_ptr<proto::WorldRobot> findBot = utils::getWorldBot(command.id(), isYellow, worldOpt);
     proto::WorldRobot robot;
@@ -125,7 +127,7 @@ std::shared_ptr<packed_protocol_message> createRobotPacket(LowLevelRobotCommand 
 
     byteArr[7] = static_cast<uint8_t>(  // K C F De UC 3 bits of geneva
         (0b10000000 & (llrc.do_kick << 7)) | (0b01000000 & (llrc.do_chip << 6)) | (0b00100000 & (llrc.kick_chip_forced << 5)) | (0b00010000 & (llrc.debug_info << 4)) |
-        (0b00001000 & (llrc.use_cam_info << 3)) | (0b00000111 & (0))); // TODO : remove geneva state
+        (0b00001000 & (llrc.use_cam_info << 3)) | (0b00000111 & (0)));  // TODO : remove geneva state
 
     byteArr[8] = static_cast<uint8_t>(  // 5 bits dribble vel | first 3 bits of
                                         // cam rotation

--- a/test/packing.cpp
+++ b/test/packing.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "roboteam_robothub/packing.h"
+
 #include <gtest/gtest.h>
 
 TEST(packingTest, it_packs) { ASSERT_TRUE(true); }


### PR DESCRIPTION
Clang-formatting style has been provided, but checks were skipped in
the past. Thus, the codebase diverted from the set clang-format settings.
The purpose of this commit is to reunify the codebase style and allow
continuous integration checks.