### PR TITLE
Two teams

### DIFF
--- a/include/RobotHub.h
+++ b/include/RobotHub.h
@@ -47,7 +47,7 @@ class RobotHub {
 
     void onRobotCommandsFromChannel1(proto::AICommand &commands);
     void onRobotCommandsFromChannel2(proto::AICommand &commands);
-    void processRobotCommands(proto::AICommand &commands, bool forTeamYellow, bool useSimulator);
+    void processRobotCommands(proto::AICommand &commands, bool forTeamYellow, bool useBasestation);
 
     void onSettingsFromChannel1(proto::Setting &setting);
     void onSettingsFromChannel2(proto::Setting &setting);

--- a/include/RobotHub.h
+++ b/include/RobotHub.h
@@ -25,8 +25,9 @@ class RobotHub {
     std::unique_ptr<simulation::SimulatorManager> simulatorManager;
     std::unique_ptr<basestation::BasestationManager> basestationManager;
 
-    proto::Setting settings;
-    proto::Setting settings2;
+    proto::Setting settingsFromChannel1;
+    proto::Setting settingsFromChannel2;
+
     proto::ChannelType robotCommandChannel;
     proto::ChannelType settingsChannel;
 
@@ -41,13 +42,15 @@ class RobotHub {
 
     void subscribe();
 
-    void sendCommandsToSimulator(const proto::AICommand &aiCmd, bool isForTeamYellow);
-    void sendCommandsToBasestation(const proto::AICommand &aiCmd);
+    void sendCommandsToSimulator(const proto::AICommand &commands, bool toTeamYellow);
+    void sendCommandsToBasestation(const proto::AICommand &commands, bool toTeamYellow);
 
-    void processAIcommand(proto::AICommand &AIcmd);
-    void processAIcommand2(proto::AICommand &AIcmd);
-    void processSettings(proto::Setting &setting);
-    void processSettings2(proto::Setting &setting);
+    void onRobotCommandsFromChannel1(proto::AICommand& commands);
+    void onRobotCommandsFromChannel2(proto::AICommand& commands);
+    void processRobotCommands(proto::AICommand &commands, bool forTeamYellow, bool useSimulator);
+    
+    void onSettingsFromChannel1(proto::Setting &setting);
+    void onSettingsFromChannel2(proto::Setting &setting);
 
     void handleRobotFeedbackFromSimulator(const simulation::RobotControlFeedback &feedback);
     void handleRobotFeedbackFromBasestation(const RobotFeedback &feedback);

--- a/include/RobotHub.h
+++ b/include/RobotHub.h
@@ -45,10 +45,10 @@ class RobotHub {
     void sendCommandsToSimulator(const proto::AICommand &commands, bool toTeamYellow);
     void sendCommandsToBasestation(const proto::AICommand &commands, bool toTeamYellow);
 
-    void onRobotCommandsFromChannel1(proto::AICommand& commands);
-    void onRobotCommandsFromChannel2(proto::AICommand& commands);
+    void onRobotCommandsFromChannel1(proto::AICommand &commands);
+    void onRobotCommandsFromChannel2(proto::AICommand &commands);
     void processRobotCommands(proto::AICommand &commands, bool forTeamYellow, bool useSimulator);
-    
+
     void onSettingsFromChannel1(proto::Setting &setting);
     void onSettingsFromChannel2(proto::Setting &setting);
 

--- a/include/RobotHub.h
+++ b/include/RobotHub.h
@@ -30,6 +30,7 @@ class RobotHub {
     proto::ChannelType settingsChannel;
 
     std::unique_ptr<proto::Subscriber<proto::AICommand>> robotCommandSubscriber;
+    std::unique_ptr<proto::Subscriber<proto::AICommand>> robotCommandSubscriber2;
     std::unique_ptr<proto::Subscriber<proto::Setting>> settingsSubscriber;
     std::unique_ptr<proto::Publisher<proto::RobotData>> feedbackPublisher;
 
@@ -38,10 +39,11 @@ class RobotHub {
 
     void subscribe();
 
-    void sendCommandsToSimulator(const proto::AICommand &aiCmd);
+    void sendCommandsToSimulator(const proto::AICommand &aiCmd, bool isForTeamYellow);
     void sendCommandsToBasestation(const proto::AICommand &aiCmd);
 
     void processAIcommand(proto::AICommand &AIcmd);
+    void processAIcommand2(proto::AICommand &AIcmd);
     void processSettings(proto::Setting &setting);
 
     void handleRobotFeedbackFromSimulator(const simulation::RobotControlFeedback &feedback);

--- a/include/RobotHub.h
+++ b/include/RobotHub.h
@@ -26,12 +26,14 @@ class RobotHub {
     std::unique_ptr<basestation::BasestationManager> basestationManager;
 
     proto::Setting settings;
+    proto::Setting settings2;
     proto::ChannelType robotCommandChannel;
     proto::ChannelType settingsChannel;
 
     std::unique_ptr<proto::Subscriber<proto::AICommand>> robotCommandSubscriber;
     std::unique_ptr<proto::Subscriber<proto::AICommand>> robotCommandSubscriber2;
     std::unique_ptr<proto::Subscriber<proto::Setting>> settingsSubscriber;
+    std::unique_ptr<proto::Subscriber<proto::Setting>> settingsSubscriber2;
     std::unique_ptr<proto::Publisher<proto::RobotData>> feedbackPublisher;
 
     int commands_sent[MAX_AMOUNT_OF_ROBOTS] = {};
@@ -45,6 +47,7 @@ class RobotHub {
     void processAIcommand(proto::AICommand &AIcmd);
     void processAIcommand2(proto::AICommand &AIcmd);
     void processSettings(proto::Setting &setting);
+    void processSettings2(proto::Setting &setting);
 
     void handleRobotFeedbackFromSimulator(const simulation::RobotControlFeedback &feedback);
     void handleRobotFeedbackFromBasestation(const RobotFeedback &feedback);

--- a/src/RobotHub.cpp
+++ b/src/RobotHub.cpp
@@ -31,6 +31,7 @@ void RobotHub::subscribe() {
     robotCommandSubscriber2 = std::make_unique<proto::Subscriber<proto::AICommand>>(proto::ROBOT_COMMANDS_SECONDARY_CHANNEL, &RobotHub::processAIcommand2, this);
 
     settingsSubscriber = std::make_unique<proto::Subscriber<proto::Setting>>(proto::SETTINGS_PRIMARY_CHANNEL, &RobotHub::processSettings, this);
+    settingsSubscriber2 = std::make_unique<proto::Subscriber<proto::Setting>>(proto::SETTINGS_SECONDARY_CHANNEL, &RobotHub::processSettings2, this);
 
     feedbackPublisher = std::make_unique<proto::Publisher<proto::RobotData>>(proto::FEEDBACK_PRIMARY_CHANNEL);
 }
@@ -79,7 +80,7 @@ void RobotHub::processAIcommand(proto::AICommand &AIcmd) {
     }
 }
 void RobotHub::processAIcommand2(proto::AICommand &AIcmd) {
-    bool isForTeamYellow = !this->settings.isyellow();
+    bool isForTeamYellow = this->settings2.isyellow();
 
     if (settings.serialmode()) {
         this->sendCommandsToBasestation(AIcmd);
@@ -88,7 +89,8 @@ void RobotHub::processAIcommand2(proto::AICommand &AIcmd) {
     }
 }
 
-void RobotHub::processSettings(proto::Setting &_settings) { settings = _settings; }
+void RobotHub::processSettings(proto::Setting &_settings) { this->settings = _settings; }
+void RobotHub::processSettings2(proto::Setting &_settings) { this->settings2 = _settings; }
 
 /* Unsafe function that can cause data races in commands_sent and feedback_received,
     as it is updated from multiple threads without guards. This should not matter

--- a/src/RobotHub.cpp
+++ b/src/RobotHub.cpp
@@ -77,11 +77,11 @@ void RobotHub::onRobotCommandsFromChannel2(proto::AICommand &commands) {
     this->processRobotCommands(commands, this->settingsFromChannel2.isyellow(), this->settingsFromChannel2.serialmode());
 }
 
-void RobotHub::processRobotCommands(proto::AICommand &commands, bool forTeamYellow, bool useSimulator) {
-    if (useSimulator) {
-        this->sendCommandsToSimulator(commands, forTeamYellow);
-    } else {
+void RobotHub::processRobotCommands(proto::AICommand &commands, bool forTeamYellow, bool useBasestation) {
+    if (useBasestation) {
         this->sendCommandsToBasestation(commands, forTeamYellow);
+    } else {
+        this->sendCommandsToSimulator(commands, forTeamYellow);
     }
 }
 

--- a/src/RobotHub.cpp
+++ b/src/RobotHub.cpp
@@ -70,10 +70,10 @@ void RobotHub::sendCommandsToBasestation(const proto::AICommand &commands, bool 
     }
 }
 
-void RobotHub::onRobotCommandsFromChannel1(proto::AICommand& commands) {
+void RobotHub::onRobotCommandsFromChannel1(proto::AICommand &commands) {
     this->processRobotCommands(commands, this->settingsFromChannel1.isyellow(), this->settingsFromChannel1.serialmode());
 }
-void RobotHub::onRobotCommandsFromChannel2(proto::AICommand& commands) {
+void RobotHub::onRobotCommandsFromChannel2(proto::AICommand &commands) {
     this->processRobotCommands(commands, this->settingsFromChannel2.isyellow(), this->settingsFromChannel2.serialmode());
 }
 
@@ -137,7 +137,7 @@ void RobotHub::handleRobotFeedbackFromSimulator(const simulation::RobotControlFe
 
 void RobotHub::handleRobotFeedbackFromBasestation(const RobotFeedback &feedback) {
     proto::RobotData feedbackToBePublished;
-    //feedbackToBePublished.set_isyellow(this->settings.isyellow()); //TODO: Get from basestation which team it owns
+    // feedbackToBePublished.set_isyellow(this->settings.isyellow()); //TODO: Get from basestation which team it owns
 
     proto::RobotFeedback *feedbackOfRobot = feedbackToBePublished.add_receivedfeedback();
     feedbackOfRobot->set_id(feedback.id);

--- a/src/RobotHub.cpp
+++ b/src/RobotHub.cpp
@@ -27,20 +27,20 @@ RobotHub::RobotHub() {
 
 void RobotHub::subscribe() {
     // TODO: choose either _PRIMARY_CHANNEL or _SECONDARY_CHANNEL based on some flag somewhere
-    robotCommandSubscriber = std::make_unique<proto::Subscriber<proto::AICommand>>(proto::ROBOT_COMMANDS_PRIMARY_CHANNEL, &RobotHub::processAIcommand, this);
-    robotCommandSubscriber2 = std::make_unique<proto::Subscriber<proto::AICommand>>(proto::ROBOT_COMMANDS_SECONDARY_CHANNEL, &RobotHub::processAIcommand2, this);
+    robotCommandSubscriber = std::make_unique<proto::Subscriber<proto::AICommand>>(proto::ROBOT_COMMANDS_PRIMARY_CHANNEL, &RobotHub::onRobotCommandsFromChannel1, this);
+    robotCommandSubscriber2 = std::make_unique<proto::Subscriber<proto::AICommand>>(proto::ROBOT_COMMANDS_SECONDARY_CHANNEL, &RobotHub::onRobotCommandsFromChannel2, this);
 
-    settingsSubscriber = std::make_unique<proto::Subscriber<proto::Setting>>(proto::SETTINGS_PRIMARY_CHANNEL, &RobotHub::processSettings, this);
-    settingsSubscriber2 = std::make_unique<proto::Subscriber<proto::Setting>>(proto::SETTINGS_SECONDARY_CHANNEL, &RobotHub::processSettings2, this);
+    settingsSubscriber = std::make_unique<proto::Subscriber<proto::Setting>>(proto::SETTINGS_PRIMARY_CHANNEL, &RobotHub::onSettingsFromChannel1, this);
+    settingsSubscriber2 = std::make_unique<proto::Subscriber<proto::Setting>>(proto::SETTINGS_SECONDARY_CHANNEL, &RobotHub::onSettingsFromChannel2, this);
 
     feedbackPublisher = std::make_unique<proto::Publisher<proto::RobotData>>(proto::FEEDBACK_PRIMARY_CHANNEL);
 }
 
-void RobotHub::sendCommandsToSimulator(const proto::AICommand &aiCmd, bool isForTeamYellow) {
+void RobotHub::sendCommandsToSimulator(const proto::AICommand &commands, bool toTeamYellow) {
     if (this->simulatorManager == nullptr) return;
 
     simulation::RobotControlCommand simCommand;
-    for (auto robotCommand : aiCmd.commands()) {
+    for (auto robotCommand : commands.commands()) {
         int id = robotCommand.id();
         float kickSpeed = robotCommand.chipper() || robotCommand.kicker() ? robotCommand.chip_kick_vel() : 0.0f;
         float kickAngle = robotCommand.chipper() ? DEFAULT_CHIPPER_ANGLE : 0.0f;
@@ -55,42 +55,38 @@ void RobotHub::sendCommandsToSimulator(const proto::AICommand &aiCmd, bool isFor
         this->commands_sent[id]++;
     }
 
-    this->simulatorManager->sendRobotControlCommand(simCommand, isForTeamYellow);
+    this->simulatorManager->sendRobotControlCommand(simCommand, toTeamYellow);
 }
 
-void RobotHub::sendCommandsToBasestation(const proto::AICommand &aiCmd) {
-    for (const proto::RobotCommand &cmd : aiCmd.commands()) {
+void RobotHub::sendCommandsToBasestation(const proto::AICommand &commands, bool toTeamYellow) {
+    for (const proto::RobotCommand &command : commands.commands()) {
         // Convert the proto::RobotCommand to a RobotCommandPayload
-        RobotCommandPayload payload = createEmbeddedCommand(cmd, aiCmd.extrapolatedworld(), settings.isyellow());
+        RobotCommandPayload payload = createEmbeddedCommand(command, commands.extrapolatedworld(), toTeamYellow);
 
         this->basestationManager->sendSerialCommand(payload);
 
         // Update statistics
-        commands_sent[cmd.id()]++;
+        commands_sent[command.id()]++;
     }
 }
 
-void RobotHub::processAIcommand(proto::AICommand &AIcmd) {
-    bool isForTeamYellow = this->settings.isyellow();
+void RobotHub::onRobotCommandsFromChannel1(proto::AICommand& commands) {
+    this->processRobotCommands(commands, this->settingsFromChannel1.isyellow(), this->settingsFromChannel1.serialmode());
+}
+void RobotHub::onRobotCommandsFromChannel2(proto::AICommand& commands) {
+    this->processRobotCommands(commands, this->settingsFromChannel2.isyellow(), this->settingsFromChannel2.serialmode());
+}
 
-    if (settings.serialmode()) {
-        this->sendCommandsToBasestation(AIcmd);
+void RobotHub::processRobotCommands(proto::AICommand &commands, bool forTeamYellow, bool useSimulator) {
+    if (useSimulator) {
+        this->sendCommandsToSimulator(commands, forTeamYellow);
     } else {
-        this->sendCommandsToSimulator(AIcmd, isForTeamYellow);
-    }
-}
-void RobotHub::processAIcommand2(proto::AICommand &AIcmd) {
-    bool isForTeamYellow = this->settings2.isyellow();
-
-    if (settings.serialmode()) {
-        this->sendCommandsToBasestation(AIcmd);
-    } else {
-        this->sendCommandsToSimulator(AIcmd, isForTeamYellow);
+        this->sendCommandsToBasestation(commands, forTeamYellow);
     }
 }
 
-void RobotHub::processSettings(proto::Setting &_settings) { this->settings = _settings; }
-void RobotHub::processSettings2(proto::Setting &_settings) { this->settings2 = _settings; }
+void RobotHub::onSettingsFromChannel1(proto::Setting &settings) { this->settingsFromChannel1 = settings; }
+void RobotHub::onSettingsFromChannel2(proto::Setting &settings) { this->settingsFromChannel2 = settings; }
 
 /* Unsafe function that can cause data races in commands_sent and feedback_received,
     as it is updated from multiple threads without guards. This should not matter
@@ -123,7 +119,6 @@ void RobotHub::printStatistics() {
         }
         ss << std::endl;
     }
-
     std::cout << ss.str();
 }
 
@@ -142,7 +137,7 @@ void RobotHub::handleRobotFeedbackFromSimulator(const simulation::RobotControlFe
 
 void RobotHub::handleRobotFeedbackFromBasestation(const RobotFeedback &feedback) {
     proto::RobotData feedbackToBePublished;
-    feedbackToBePublished.set_isyellow(this->settings.isyellow());
+    //feedbackToBePublished.set_isyellow(this->settings.isyellow()); //TODO: Get from basestation which team it owns
 
     proto::RobotFeedback *feedbackOfRobot = feedbackToBePublished.add_receivedfeedback();
     feedbackOfRobot->set_id(feedback.id);


### PR DESCRIPTION
Currently, robothub only listens to one channel, meaning robot commands are only received from one AI. This PR will add a listener to the secondary channel, and rename some functions and variables to prevent confusion which one belongs to which channel.