### PR TITLE
Add world updating

### DIFF
--- a/include/RobotHub.h
+++ b/include/RobotHub.h
@@ -52,6 +52,8 @@ class RobotHub {
 
     void onSettings(const proto::Setting &setting);
 
+    void onWorld(const proto::State &world);
+
     void handleRobotFeedbackFromSimulator(const simulation::RobotControlFeedback &feedback);
     void handleRobotFeedbackFromBasestation(const RobotFeedback &feedback);
     bool sendRobotFeedback(const proto::RobotData &feedback);

--- a/src/RobotHub.cpp
+++ b/src/RobotHub.cpp
@@ -96,9 +96,10 @@ void RobotHub::sendCommandsToBasestation(const proto::AICommand &commands, bool 
         command.angularControl = protoCommand.use_angle();
         command.angle = protoCommand.w();
 
+        // TODO: Strategically update robot angle when robot stands still instead of always using camera angle
         if (bot != nullptr) {
             command.useCameraAngle = true;
-            command.cameraAngle = bot->w();
+            command.cameraAngle = bot->angle();
         } else {
             command.useCameraAngle = false;
             command.cameraAngle = 0.0;


### PR DESCRIPTION
RobotHub used to receive a world via the robot commands, but this has a delay from AI.
In this PR I make Robothub listen to the world that RTT_World publishes, resulting in a more up to date world, and less network traffic overhead.