### PR TITLE
Fix/angle and rem

### DIFF
--- a/src/RobotHub.cpp
+++ b/src/RobotHub.cpp
@@ -101,7 +101,7 @@ void RobotHub::sendCommandsToBasestation(const proto::AICommand &commands, utils
 
         if (bot != nullptr) {
             command.useCameraAngle = true;
-            command.cameraAngle = bot->w();
+            command.cameraAngle = bot->angle();
         } else {
             command.useCameraAngle = false;
             command.cameraAngle = 0.0;


### PR DESCRIPTION
Robothub is supposed to send the angle according to the camera to the robots. The angular velocity according to the camera of the robot was accidentally sent however, so this PR fixes that.