### PR TITLE
Feature/sim configuration

### DIFF
--- a/include/RobotHub.h
+++ b/include/RobotHub.h
@@ -7,6 +7,7 @@
 #include <RobotFeedbackNetworker.hpp>
 #include <SettingsNetworker.hpp>
 #include <WorldNetworker.hpp>
+#include <SimulationConfigurationNetworker.hpp>
 #include <basestation/BasestationManager.hpp>
 #include <exception>
 #include <functional>
@@ -36,6 +37,7 @@ class RobotHub {
     std::unique_ptr<rtt::net::RobotCommandsYellowSubscriber> robotCommandsYellowSubscriber;
     std::unique_ptr<rtt::net::SettingsSubscriber> settingsSubscriber;
     std::unique_ptr<rtt::net::RobotFeedbackPublisher> robotFeedbackPublisher;
+    std::unique_ptr<rtt::net::SimulationConfigurationSubscriber> simulationConfigurationSubscriber;
 
     int commands_sent[MAX_AMOUNT_OF_ROBOTS] = {};
     int feedback_received[MAX_AMOUNT_OF_ROBOTS] = {};
@@ -50,6 +52,8 @@ class RobotHub {
     void processRobotCommands(const proto::AICommand &commands, utils::TeamColor color, utils::RobotHubMode mode);
 
     void onSettings(const proto::Setting &setting);
+
+    void onSimulationConfiguration(const proto::SimulationConfiguration &configuration);
 
     void handleRobotFeedbackFromSimulator(const simulation::RobotControlFeedback &feedback);
     void handleRobotFeedbackFromBasestation(const RobotFeedback &feedback, utils::TeamColor team);

--- a/include/simulation/ConfigurationCommand.hpp
+++ b/include/simulation/ConfigurationCommand.hpp
@@ -3,6 +3,7 @@
 #include <ssl_simulation_control.pb.h>
 
 #include <simulation/RobotProperties.hpp>
+#include <utilities.h>
 
 namespace rtt::robothub::simulation {
 /*  This class contains command information to configure and setup the simulator.
@@ -21,10 +22,10 @@ class ConfigurationCommand {
     void setBallLocation(float x, float y, float z, float xVelocity, float yVelocity, float zVelocity, bool velocityInRolling, bool teleportSafely, bool byForce);
     // Orientation is a global rotation relative to the field.
     // shouldBePresentOnField will make a robot (dis)appear accordingly.
-    void addRobotLocation(int id, bool isFromTeamYellow, float x, float y, float xVelocity, float yVelocity, float angularVelocity, float orientation, bool shouldBePresentOnField,
+    void addRobotLocation(int id, utils::TeamColor color, float x, float y, float xVelocity, float yVelocity, float angularVelocity, float orientation, bool shouldBePresentOnField,
                           bool byForce);
     void setSimulationSpeed(float speed);
-    void addRobotSpecs(int id, bool isFromTeamYellow, RobotProperties& robotProperties);
+    void addRobotSpecs(int id, utils::TeamColor color, RobotProperties& robotProperties);
     void setVisionPort(int port);
 
     proto::simulation::SimulatorCommand& getPacket();

--- a/include/simulation/SimulatorManager.hpp
+++ b/include/simulation/SimulatorManager.hpp
@@ -7,13 +7,14 @@
 #include <ssl_simulation_robot_control.pb.h>
 #include <ssl_simulation_robot_feedback.pb.h>
 #include <ssl_vision_geometry.pb.h>
+
+#include <simulation/ConfigurationCommand.hpp>
+#include <simulation/Feedback.hpp>
+#include <simulation/RobotControlCommand.hpp>
 #include <utilities.h>
 
 #include <QtNetwork>
 #include <functional>
-#include <simulation/ConfigurationCommand.hpp>
-#include <simulation/Feedback.hpp>
-#include <simulation/RobotControlCommand.hpp>
 #include <stdexcept>
 #include <string>
 #include <thread>

--- a/include/utilities.h
+++ b/include/utilities.h
@@ -65,38 +65,4 @@ static int char2int(char input) {
     }
 }
 
-/*
-// Copy of getWorldBot() because I don't want to pull in tactics as a
-// dependency. If this function is moved to utils, we can use that
-[[maybe_unused]] static std::shared_ptr<proto::WorldRobot> getWorldBot(unsigned int id, bool teamYellow, const proto::World& world) {
-    /** Heavily inefficient, copying over all the robots :(
-     * If this was C++20 I would've picked std::span, but for now just use
-     * yellow() / blue()
-     *
-    // if (ourTeam) {
-    //     robots = std::vector<roboteam_proto::WorldRobot>(
-    //     world.yellow().begin(),  world.yellow().end());
-    // } else {
-    //     robots =
-    //     std::vector<roboteam_proto::WorldRobot>(world.blue().begin(),
-    //     world.blue().end());
-    // }
-
-    // Prevent a copy.
-
-    auto& robots = teamYellow ? world.yellow() : world.blue();
-
-    // https://en.cppreference.com/w/cpp/algorithm/find
-    // Should do that instead, but whatever, doesn't really matter in terms of
-    // performance
-    for (const auto& bot : robots) {
-        proto::WorldRobot a = bot;
-        if (bot.id() == id) {
-            return std::make_shared<proto::WorldRobot>(bot);
-        }
-    }
-    return nullptr;
-}
-*/
-
 }  // namespace rtt::robothub::utils

--- a/src/RobotHub.cpp
+++ b/src/RobotHub.cpp
@@ -44,6 +44,10 @@ bool RobotHub::subscribe() {
     auto settingsCallback = std::bind(&RobotHub::onSettings, this, std::placeholders::_1);
     this->settingsSubscriber = std::make_unique<rtt::net::SettingsSubscriber>(settingsCallback);
 
+    this->simulationConfigurationSubscriber = std::make_unique<rtt::net::SimulationConfigurationSubscriber>([&](const proto::SimulationConfiguration& config){
+        this->onSimulationConfiguration(config);
+    });
+
     this->robotFeedbackPublisher = std::make_unique<rtt::net::RobotFeedbackPublisher>();
 
     // All networkers should not be a nullptr
@@ -213,7 +217,8 @@ void RobotHub::onSimulationConfiguration(const proto::SimulationConfiguration &c
         );
     }
 
-    this->simulatorManager->sendConfigurationCommand(configCommand);
+    int bytesSent = this->simulatorManager->sendConfigurationCommand(configCommand);
+    // TODO: Put these bytes sent into nice statistics output (low priority)
 }
 
 /* Unsafe function that can cause data races in commands_sent and feedback_received,

--- a/src/simulation/ConfigurationCommand.cpp
+++ b/src/simulation/ConfigurationCommand.cpp
@@ -14,11 +14,11 @@ void ConfigurationCommand::setBallLocation(float x, float y, float z, float xVel
     tpBallCommand->set_teleport_safely(teleportSafely);
     tpBallCommand->set_by_force(byForce);
 }
-void ConfigurationCommand::addRobotLocation(int id, bool isFromTeamYellow, float x, float y, float xVelocity, float yVelocity, float angularVelocity, float orientation,
+void ConfigurationCommand::addRobotLocation(int id, utils::TeamColor color, float x, float y, float xVelocity, float yVelocity, float angularVelocity, float orientation,
                                             bool shouldBePresentOnField, bool byForce) {
     proto::simulation::TeleportRobot* tpRobotCommand = this->configurationCommand.mutable_control()->add_teleport_robot();
     tpRobotCommand->mutable_id()->set_id(id);
-    tpRobotCommand->mutable_id()->set_team(isFromTeamYellow ? proto::simulation::Team::YELLOW : proto::simulation::Team::BLUE);
+    tpRobotCommand->mutable_id()->set_team(color == utils::TeamColor::YELLOW ? proto::simulation::Team::YELLOW : proto::simulation::Team::BLUE);
     tpRobotCommand->set_x(x);
     tpRobotCommand->set_y(y);
     tpRobotCommand->set_v_x(xVelocity);
@@ -29,11 +29,11 @@ void ConfigurationCommand::addRobotLocation(int id, bool isFromTeamYellow, float
     tpRobotCommand->set_by_force(byForce);
 }
 void ConfigurationCommand::setSimulationSpeed(float speed) { this->configurationCommand.mutable_control()->set_simulation_speed(speed); }
-void ConfigurationCommand::addRobotSpecs(int id, bool isFromTeamYellow, RobotProperties& robotProperties) {
+void ConfigurationCommand::addRobotSpecs(int id, utils::TeamColor color, RobotProperties& robotProperties) {
     proto::simulation::RobotSpecs* specs = this->configurationCommand.mutable_config()->add_robot_specs();
 
     specs->mutable_id()->set_id(id);
-    specs->mutable_id()->set_team(isFromTeamYellow ? proto::simulation::Team::YELLOW : proto::simulation::Team::BLUE);
+    specs->mutable_id()->set_team(color == utils::TeamColor::YELLOW ? proto::simulation::Team::YELLOW : proto::simulation::Team::BLUE);
     specs->set_radius(robotProperties.radius);
     specs->set_height(robotProperties.height);
     specs->set_mass(robotProperties.mass);


### PR DESCRIPTION
This PR makes RobotHub listen to Simulation Configuration commands, and forwards them to the connected simulator.

This PR is dependent on the [PR in Networking](https://github.com/RoboTeamTwente/roboteam_networking/pull/3)