### PR TITLE
Fix feedback team color

### DIFF
--- a/include/basestation/Basestation.hpp
+++ b/include/basestation/Basestation.hpp
@@ -6,6 +6,7 @@
 #include <functional>
 #include <string>
 #include <thread>
+#include <memory>
 
 namespace rtt::robothub::basestation {
 
@@ -24,9 +25,10 @@ class Basestation {
 
     // Compares the underlying device of this basestation with the given device
     bool operator==(libusb_device* device) const;
+    bool operator==(std::shared_ptr<Basestation> otherBasestation) const;
 
     bool sendMessageToBasestation(BasestationMessage& message) const;
-    void setIncomingMessageCallback(std::function<void(const BasestationMessage&)> callback);
+    void setIncomingMessageCallback(std::function<void(const BasestationMessage&, WirelessChannel)> callback);
 
     WirelessChannel getChannel() const;
 
@@ -47,7 +49,7 @@ class Basestation {
     std::thread incomingMessageListenerThread;
     void listenForIncomingMessages();
     void handleIncomingMessage(const BasestationMessage& message);
-    std::function<void(const BasestationMessage&)> incomingMessageCallback;
+    std::function<void(const BasestationMessage&, WirelessChannel)> incomingMessageCallback;
 
     // Sends a message to the basestation that asks what its channel is
     bool requestChannelOfBasestation();

--- a/include/basestation/BasestationCollection.hpp
+++ b/include/basestation/BasestationCollection.hpp
@@ -46,6 +46,7 @@ class BasestationCollection {
     std::function<void(const BasestationMessage&, utils::TeamColor color)> messageFromBasestationCallback;
 
     static WirelessChannel getWirelessChannelCorrespondingTeamColor(utils::TeamColor color);
+    static utils::TeamColor getTeamColorCorrespondingWirelessChannel(WirelessChannel channel);
     static bool basestationIsInDeviceList(std::shared_ptr<Basestation> basestation, const std::vector<libusb_device*>& devices);
     static bool deviceIsInBasestationList(libusb_device* device, const std::vector<std::shared_ptr<Basestation>>& basestations);
 };

--- a/src/basestation/Basestation.cpp
+++ b/src/basestation/Basestation.cpp
@@ -78,10 +78,14 @@ bool Basestation::operator==(libusb_device* otherDevice) const {
     uint8_t otherAddress = libusb_get_device_address(otherDevice);
     return this->address == otherAddress;
 }
+bool Basestation::operator==(std::shared_ptr<Basestation> otherBasestation) const {
+    return otherBasestation != nullptr
+        && this->address == otherBasestation->address;
+}
 
 bool Basestation::sendMessageToBasestation(BasestationMessage& message) const { return this->writeBasestationMessage(message); }
 
-void Basestation::setIncomingMessageCallback(std::function<void(const BasestationMessage&)> callback) { this->incomingMessageCallback = callback; }
+void Basestation::setIncomingMessageCallback(std::function<void(const BasestationMessage&, WirelessChannel)> callback) { this->incomingMessageCallback = callback; }
 
 WirelessChannel Basestation::getChannel() const { return this->channel; }
 
@@ -157,7 +161,7 @@ void Basestation::handleIncomingMessage(const BasestationMessage& message) {
 
     // And in any case, just forward the message to the callback
     if (this->incomingMessageCallback != nullptr) {
-        this->incomingMessageCallback(message);
+        this->incomingMessageCallback(message, this->channel);
     }
 }
 


### PR DESCRIPTION
First of all, the getUnselectedBasestations function was incorrect, as it used the == operator to compare pointers to basestations instead of basestations themselves, so that is fixed

Second of all, now the basestation itself decides what teamcolor the feedback will have depending on the basestations frequency instead of what color the basestation should have. This means the color of the feedback is decided earlier on in the callback chain, hence the addition of WirelessChannel in some callbacks