### PR TITLE
Channel changing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,12 @@ target_link_libraries(roboteam_robothub_enumerate_usb
         lib::usb
 )
 
+# Create the make file for test/sendRobotCommands.cpp
+add_executable(test_sendRobotCommands
+        "test/SendRobotCommands.cpp"
+)
+target_link_libraries(test_sendRobotCommands PRIVATE roboteam_networking)
+
 # Create make file for simulation formation test
 add_executable(test_formation
         test/sendFormationToSimulator.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ target_include_directories(simulator_manager PUBLIC "include")
 target_link_libraries(simulator_manager PUBLIC
         simulation_manager_proto
         Qt5::Network
+        roboteam_utils
 )
 
 # Create the make file for the basestationManager library
@@ -48,6 +49,7 @@ target_include_directories(basestation_manager PUBLIC
 target_link_libraries(basestation_manager PUBLIC
         Threads::Threads
         lib::usb
+        roboteam_utils
 )
 
 # Create the make file for RobotHub, which uses the basestationManager and simulationManager library
@@ -59,6 +61,7 @@ target_link_libraries(roboteam_robothub
         PRIVATE simulator_manager
         PRIVATE basestation_manager
         PRIVATE roboteam_networking
+        PRIVATE roboteam_utils
 )
 
 # Create the make file for robothub_enumerate_usb

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ target_link_libraries(basestation_manager PUBLIC
 )
 
 # Create the make file for RobotHub, which uses the basestationManager and simulationManager library
-add_executable(roboteam_robothub "src/RobotHub.cpp")
+add_executable(roboteam_robothub "src/RobotHubStatistics.cpp" "src/RobotHub.cpp")
 target_include_directories(roboteam_robothub
         PRIVATE include
 )

--- a/include/RobotHub.h
+++ b/include/RobotHub.h
@@ -25,7 +25,8 @@ class RobotHub {
    public:
     RobotHub();
 
-    RobotHubStatistics& getStatistics();
+    const RobotHubStatistics& getStatistics();
+    void resetStatistics();
 
    private:
     std::unique_ptr<simulation::SimulatorManager> simulatorManager;
@@ -56,7 +57,7 @@ class RobotHub {
 
     void handleRobotFeedbackFromSimulator(const simulation::RobotControlFeedback &feedback);
     void handleRobotFeedbackFromBasestation(const RobotFeedback &feedback, utils::TeamColor team);
-    bool sendRobotFeedback(const proto::RobotData &feedback);
+    bool sendRobotFeedback(const proto::RobotData &feedback) const;
 };
 
 class FailedToInitializeNetworkersException : public std::exception {

--- a/include/RobotHub.h
+++ b/include/RobotHub.h
@@ -57,7 +57,7 @@ class RobotHub {
 
     void handleRobotFeedbackFromSimulator(const simulation::RobotControlFeedback &feedback);
     void handleRobotFeedbackFromBasestation(const RobotFeedback &feedback, utils::TeamColor team);
-    bool sendRobotFeedback(const proto::RobotData &feedback) const;
+    bool sendRobotFeedback(const proto::RobotData &feedback);
 };
 
 class FailedToInitializeNetworkersException : public std::exception {

--- a/include/RobotHub.h
+++ b/include/RobotHub.h
@@ -2,13 +2,13 @@
 
 #include <libusb-1.0/libusb.h>
 #include <utilities.h>
-#include <RobotHubStatistics.hpp>
 
 #include <RobotCommandsNetworker.hpp>
 #include <RobotFeedbackNetworker.hpp>
+#include <RobotHubStatistics.hpp>
 #include <SettingsNetworker.hpp>
-#include <WorldNetworker.hpp>
 #include <SimulationConfigurationNetworker.hpp>
+#include <WorldNetworker.hpp>
 #include <basestation/BasestationManager.hpp>
 #include <exception>
 #include <functional>
@@ -25,7 +25,7 @@ class RobotHub {
    public:
     RobotHub();
 
-    const RobotHubStatistics& getStatistics();
+    const RobotHubStatistics &getStatistics();
     void resetStatistics();
 
    private:
@@ -48,7 +48,7 @@ class RobotHub {
     void sendCommandsToSimulator(const proto::AICommand &commands, utils::TeamColor color);
     void sendCommandsToBasestation(const proto::AICommand &commands, utils::TeamColor color);
 
-    std::mutex onRobotCommandsMutex; // Guards the onRobotCommands function, as this can be called from two callback threads
+    std::mutex onRobotCommandsMutex;  // Guards the onRobotCommands function, as this can be called from two callback threads
     void onRobotCommands(const proto::AICommand &commands, utils::TeamColor color);
 
     void onSettings(const proto::Setting &setting);

--- a/include/RobotHubStatistics.hpp
+++ b/include/RobotHubStatistics.hpp
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <basestation/BasestationManager.hpp>
+#include <utilities.h>
+#include <string>
+#include <chrono>
+#include <array>
+
+namespace rtt::robothub {
+
+constexpr int MAX_ROBOT_STATISTICS = 16;
+
+class RobotHubStatistics {
+public:
+    RobotHubStatistics();
+
+    void resetValues();
+
+    basestation::BasestationManagerStatus basestationManagerStatus;
+
+    utils::RobotHubMode robotHubMode;
+
+    int yellowTeamBytesSent;
+    int blueTeamBytesSent;
+    int feedbackBytesSent;
+    int yellowTeamPacketsDropped;
+    int blueTeamPacketsDropped;
+    int feedbackPacketsDropped;
+
+    void incrementCommandsReceivedCounter(int id, utils::TeamColor color);
+    void incrementFeedbackReceivedCounter(int id, utils::TeamColor color);
+
+    void print();
+private:
+    std::chrono::time_point<std::chrono::steady_clock> startTime;
+
+    std::array<int, MAX_ROBOT_STATISTICS> yellowCommandsSent;
+    std::array<int, MAX_ROBOT_STATISTICS> yellowFeedbackReceived;
+    
+    std::array<int, MAX_ROBOT_STATISTICS> blueCommandsSent;
+    std::array<int, MAX_ROBOT_STATISTICS> blueFeedbackReceived;
+    
+    std::string getRobotStats(int id, utils::TeamColor team) const;
+    std::string getRunTime();
+    std::string getRobotHubMode();
+    std::string getAmountOfBasestations();
+    std::string getWantedBasestations();
+    std::string getSelectedBasestations();
+
+    std::string numberToSideBox(int n);
+
+    template<typename ... Args>
+    static std::string string_format( const std::string& format, Args ... args );
+
+    static std::string wantedBasestationsToString(basestation::WantedBasestations wantedBasestations);
+};
+
+} // namespace rtt::robothub

--- a/include/RobotHubStatistics.hpp
+++ b/include/RobotHubStatistics.hpp
@@ -1,17 +1,18 @@
 #pragma once
 
-#include <basestation/BasestationManager.hpp>
 #include <utilities.h>
-#include <string>
-#include <chrono>
+
 #include <array>
+#include <basestation/BasestationManager.hpp>
+#include <chrono>
+#include <string>
 
 namespace rtt::robothub {
 
 constexpr int MAX_ROBOT_STATISTICS = 16;
 
 class RobotHubStatistics {
-public:
+   public:
     RobotHubStatistics();
 
     void resetValues();
@@ -31,15 +32,16 @@ public:
     void incrementFeedbackReceivedCounter(int id, utils::TeamColor color);
 
     void print() const;
-private:
+
+   private:
     std::chrono::time_point<std::chrono::steady_clock> startTime;
 
     std::array<int, MAX_ROBOT_STATISTICS> yellowCommandsSent;
     std::array<int, MAX_ROBOT_STATISTICS> yellowFeedbackReceived;
-    
+
     std::array<int, MAX_ROBOT_STATISTICS> blueCommandsSent;
     std::array<int, MAX_ROBOT_STATISTICS> blueFeedbackReceived;
-    
+
     std::string getRobotStats(int id, utils::TeamColor team) const;
     std::string getRunTime() const;
     std::string getRobotHubMode() const;
@@ -49,10 +51,10 @@ private:
 
     std::string numberToSideBox(int n) const;
 
-    template<typename ... Args>
-    static std::string string_format( const std::string& format, Args ... args );
+    template <typename... Args>
+    static std::string string_format(const std::string& format, Args... args);
 
     static std::string wantedBasestationsToString(basestation::WantedBasestations wantedBasestations);
 };
 
-} // namespace rtt::robothub
+}  // namespace rtt::robothub

--- a/include/RobotHubStatistics.hpp
+++ b/include/RobotHubStatistics.hpp
@@ -30,7 +30,7 @@ public:
     void incrementCommandsReceivedCounter(int id, utils::TeamColor color);
     void incrementFeedbackReceivedCounter(int id, utils::TeamColor color);
 
-    void print();
+    void print() const;
 private:
     std::chrono::time_point<std::chrono::steady_clock> startTime;
 
@@ -41,13 +41,13 @@ private:
     std::array<int, MAX_ROBOT_STATISTICS> blueFeedbackReceived;
     
     std::string getRobotStats(int id, utils::TeamColor team) const;
-    std::string getRunTime();
-    std::string getRobotHubMode();
-    std::string getAmountOfBasestations();
-    std::string getWantedBasestations();
-    std::string getSelectedBasestations();
+    std::string getRunTime() const;
+    std::string getRobotHubMode() const;
+    std::string getAmountOfBasestations() const;
+    std::string getWantedBasestations() const;
+    std::string getSelectedBasestations() const;
 
-    std::string numberToSideBox(int n);
+    std::string numberToSideBox(int n) const;
 
     template<typename ... Args>
     static std::string string_format( const std::string& format, Args ... args );

--- a/include/basestation/Basestation.hpp
+++ b/include/basestation/Basestation.hpp
@@ -40,10 +40,10 @@ class Basestation {
     static std::string wirelessChannelToString(WirelessChannel channel);
 
    private:
-    libusb_device* device;               // Corresponds to the basestation itself
-    uint8_t address;                     // USB address the basestation is connected to
-    libusb_device_handle* deviceHandle;  // Handle on which IO can be performed
-    WirelessChannel channel;             // Channel at which the basestation sends messages to robots
+    libusb_device* device;              // Corresponds to the basestation itself
+    libusb_device_handle* deviceHandle; // Handle on which IO can be performed
+    WirelessChannel channel;            // Channel at which the basestation sends messages to robots
+    uint8_t serialIdentifier;           // Unique identifier of basestations, used for comparing
 
     bool shouldListenForIncomingMessages;
     std::thread incomingMessageListenerThread;
@@ -58,6 +58,8 @@ class Basestation {
     bool readBasestationMessage(BasestationMessage& message) const;
     // Writes the given message directly to the basestation
     bool writeBasestationMessage(BasestationMessage& message) const;
+
+    static uint8_t getSerialIdentifierOfDevice(libusb_device* device);
 };
 
 class FailedToOpenDeviceException : public std::exception {

--- a/include/basestation/Basestation.hpp
+++ b/include/basestation/Basestation.hpp
@@ -35,7 +35,8 @@ class Basestation {
     bool operator==(const BasestationIdentifier& otherBasestationID) const;
     bool operator==(std::shared_ptr<Basestation> otherBasestation) const;
 
-    bool sendMessageToBasestation(BasestationMessage& message) const;
+    // Sends message to basestation. Returns bytes sent, -1 for error
+    int sendMessageToBasestation(BasestationMessage& message) const;
     void setIncomingMessageCallback(std::function<void(const BasestationMessage&, const BasestationIdentifier&)> callback);
 
     const BasestationIdentifier& getIdentifier() const;
@@ -52,10 +53,10 @@ class Basestation {
     void listenForIncomingMessages();
     std::function<void(const BasestationMessage&, const BasestationIdentifier&)> incomingMessageCallback;
 
-    // Reads a message directly from the basestation and stores it in the given message
+    // Reads a message directly from the basestation and stores it in the given message. Returns success
     bool readBasestationMessage(BasestationMessage& message) const;
-    // Writes the given message directly to the basestation
-    bool writeBasestationMessage(BasestationMessage& message) const;
+    // Writes the given message directly to the basestation. Returns bytes sent
+    int writeBasestationMessage(BasestationMessage& message) const;
 
     static const BasestationIdentifier getIdentifierOfDevice(libusb_device* device);
 };

--- a/include/basestation/Basestation.hpp
+++ b/include/basestation/Basestation.hpp
@@ -4,9 +4,9 @@
 
 #include <exception>
 #include <functional>
+#include <memory>
 #include <string>
 #include <thread>
-#include <memory>
 
 namespace rtt::robothub::basestation {
 
@@ -44,9 +44,9 @@ class Basestation {
     static bool isDeviceABasestation(libusb_device* const device);
 
    private:
-    libusb_device* const device;              // Corresponds to the basestation itself
-    libusb_device_handle* deviceHandle; // Handle on which IO can be performed
-    const BasestationIdentifier identifier;   // An identifier object that uniquely represents this basestation
+    libusb_device* const device;             // Corresponds to the basestation itself
+    libusb_device_handle* deviceHandle;      // Handle on which IO can be performed
+    const BasestationIdentifier identifier;  // An identifier object that uniquely represents this basestation
 
     bool shouldListenForIncomingMessages;
     std::thread incomingMessageListenerThread;

--- a/include/basestation/Basestation.hpp
+++ b/include/basestation/Basestation.hpp
@@ -22,6 +22,7 @@ typedef struct BasestationIdentifier {
 
     bool operator==(const BasestationIdentifier& other) const;
     bool operator<(const BasestationIdentifier& other) const;
+    std::string toString() const;
 } BasestationIdentifier;
 
 class Basestation {

--- a/include/basestation/Basestation.hpp
+++ b/include/basestation/Basestation.hpp
@@ -16,8 +16,6 @@ typedef struct BasestationMessage {
     uint8_t payloadBuffer[BASESTATION_MESSAGE_BUFFER_SIZE];
 } BasestationMessage;
 
-enum class WirelessChannel : unsigned int { YELLOW_CHANNEL = 0, BLUE_CHANNEL = 1, UNKNOWN = 2 };
-
 class Basestation {
    public:
     explicit Basestation(libusb_device* device);
@@ -25,34 +23,25 @@ class Basestation {
 
     // Compares the underlying device of this basestation with the given device
     bool operator==(libusb_device* device) const;
+    bool operator==(uint8_t otherBasestationSerialID) const; // Assumes serial id is that of a basestation device
     bool operator==(std::shared_ptr<Basestation> otherBasestation) const;
 
     bool sendMessageToBasestation(BasestationMessage& message) const;
-    void setIncomingMessageCallback(std::function<void(const BasestationMessage&, WirelessChannel)> callback);
+    void setIncomingMessageCallback(std::function<void(const BasestationMessage&, uint8_t basestationID)> callback);
 
-    WirelessChannel getChannel() const;
+    uint8_t getSerialID() const;
 
     static bool isDeviceABasestation(libusb_device* device);
-    // Converts a WirelessChannel to a value that can be used in REM
-    static bool wirelessChannelToREMChannel(WirelessChannel channel);
-    // Converts a wireless channel value from REM to a WirelessChannel
-    static WirelessChannel remChannelToWirelessChannel(bool remChannel);
-    static std::string wirelessChannelToString(WirelessChannel channel);
 
    private:
     libusb_device* device;              // Corresponds to the basestation itself
     libusb_device_handle* deviceHandle; // Handle on which IO can be performed
-    WirelessChannel channel;            // Channel at which the basestation sends messages to robots
-    uint8_t serialIdentifier;           // Unique identifier of basestations, used for comparing
+    uint8_t serialID;                   // Unique identifier of basestations, used for comparing
 
     bool shouldListenForIncomingMessages;
     std::thread incomingMessageListenerThread;
     void listenForIncomingMessages();
-    void handleIncomingMessage(const BasestationMessage& message);
-    std::function<void(const BasestationMessage&, WirelessChannel)> incomingMessageCallback;
-
-    // Sends a message to the basestation that asks what its channel is
-    bool requestChannelOfBasestation();
+    std::function<void(const BasestationMessage&, uint8_t basestationIdentifier)> incomingMessageCallback;
 
     // Reads a message directly from the basestation and stores it in the given message
     bool readBasestationMessage(BasestationMessage& message) const;

--- a/include/basestation/Basestation.hpp
+++ b/include/basestation/Basestation.hpp
@@ -36,6 +36,7 @@ class Basestation {
    private:
     libusb_device* device;              // Corresponds to the basestation itself
     libusb_device_handle* deviceHandle; // Handle on which IO can be performed
+    // TODO: Make identifier object that combines serial ID and usb port address
     uint8_t serialID;                   // Unique identifier of basestations, used for comparing
 
     bool shouldListenForIncomingMessages;

--- a/include/basestation/Basestation.hpp
+++ b/include/basestation/Basestation.hpp
@@ -22,29 +22,29 @@ typedef struct BasestationIdentifier {
 
     bool operator==(const BasestationIdentifier& other) const;
     bool operator<(const BasestationIdentifier& other) const;
-    std::string toString() const;
+    const std::string toString() const;
 } BasestationIdentifier;
 
 class Basestation {
    public:
-    explicit Basestation(libusb_device* device);
+    explicit Basestation(libusb_device* const device);
     ~Basestation();
 
     // Compares the underlying device of this basestation with the given device
-    bool operator==(libusb_device* device) const;
+    bool operator==(libusb_device* const device) const;
     bool operator==(const BasestationIdentifier& otherBasestationID) const;
-    bool operator==(std::shared_ptr<Basestation> otherBasestation) const;
+    bool operator==(const std::shared_ptr<Basestation>& otherBasestation) const;
 
     // Sends message to basestation. Returns bytes sent, -1 for error
     int sendMessageToBasestation(BasestationMessage& message) const;
-    void setIncomingMessageCallback(std::function<void(const BasestationMessage&, const BasestationIdentifier&)> callback);
+    void setIncomingMessageCallback(const std::function<void(const BasestationMessage&, const BasestationIdentifier&)>& callback);
 
     const BasestationIdentifier& getIdentifier() const;
 
-    static bool isDeviceABasestation(libusb_device* device);
+    static bool isDeviceABasestation(libusb_device* const device);
 
    private:
-    libusb_device* device;              // Corresponds to the basestation itself
+    libusb_device* const device;              // Corresponds to the basestation itself
     libusb_device_handle* deviceHandle; // Handle on which IO can be performed
     const BasestationIdentifier identifier;   // An identifier object that uniquely represents this basestation
 
@@ -58,7 +58,7 @@ class Basestation {
     // Writes the given message directly to the basestation. Returns bytes sent
     int writeBasestationMessage(BasestationMessage& message) const;
 
-    static const BasestationIdentifier getIdentifierOfDevice(libusb_device* device);
+    static const BasestationIdentifier getIdentifierOfDevice(libusb_device* const device);
 };
 
 class FailedToOpenDeviceException : public std::exception {

--- a/include/basestation/BasestationCollection.hpp
+++ b/include/basestation/BasestationCollection.hpp
@@ -19,6 +19,13 @@ enum class WirelessChannel : unsigned int { YELLOW_CHANNEL = 0, BLUE_CHANNEL = 1
 // Represents which combination of basestations is wanted
 enum class WantedBasestations { ONLY_YELLOW, ONLY_BLUE, YELLOW_AND_BLUE, NEITHER_YELLOW_NOR_BLUE };
 
+typedef struct BasestationCollectionStatus {
+   WantedBasestations wantedBasestations;
+   bool hasYellowBasestation;
+   bool hasBlueBasestation;
+   int amountOfBasestations;
+} BasestationCollectionStatus;
+
 /* This class will take any collection of basestations, and will pick two basestations that
    can send messages to the blue and the yellow robots. It does this by asking the basestations
    what channel they currently use, and if necessary, request them to change it. */
@@ -37,7 +44,7 @@ class BasestationCollection {
     void setIncomingMessageCallback(std::function<void(const BasestationMessage&, utils::TeamColor)> callback);
 
     // Prints the current status of the collection directly to the console
-    void printCollection();
+    const BasestationCollectionStatus getStatus();
 
    private:
     // Collection and selection of basestations

--- a/include/basestation/BasestationCollection.hpp
+++ b/include/basestation/BasestationCollection.hpp
@@ -9,51 +9,61 @@
 #include <mutex>
 #include <thread>
 #include <vector>
-
 #include <map>
 
 namespace rtt::robothub::basestation {
 
+// An enum that represents on which channel a basestation emits messages with robots
 enum class WirelessChannel : unsigned int { YELLOW_CHANNEL = 0, BLUE_CHANNEL = 1, UNKNOWN = 2 };
 
+/* This class will take any collection of basestations, and will pick two basestations that
+   can send messages to the blue and the yellow robots. It does this by asking the basestations
+   what channel they currently use, and if necessary, request them to change it. */
 class BasestationCollection {
    public:
     BasestationCollection();
     ~BasestationCollection();
 
-    void updateBasestationList(const std::vector<libusb_device*>& pluggedBasestationDevices);
+    // This function makes sure the collection is up to date. Call this function frequently
+    void updateBasestationCollection(const std::vector<libusb_device*>& pluggedBasestationDevices);
 
+    // Sends a message to the basestation of the given team. Returns success
     bool sendMessageToBasestation(BasestationMessage& message, utils::TeamColor teamColor);
 
+    // Set a callback function to receive all messages from the two basestations of the teams
     void setIncomingMessageCallback(std::function<void(const BasestationMessage&, utils::TeamColor)> callback);
 
+    // Prints the current status of the collection directly to the console
     void printCollection() const;
 
    private:
     // Collection and selection of basestations
-    std::vector<std::shared_ptr<Basestation>> basestations;
-    std::shared_ptr<Basestation> blueBasestation;
-    std::shared_ptr<Basestation> yellowBasestation;
+    std::vector<std::shared_ptr<Basestation>> basestations; // All basestations
+    std::shared_ptr<Basestation> yellowBasestation; // Basestation selected for yellow team
+    std::shared_ptr<Basestation> blueBasestation; // Basestation selected for blue team
+    // TODO: Make basestations and yellow and blue basestation thread safe
 
     // Keeps track of which basestation has which wireless channel
     std::map<uint8_t, WirelessChannel> basestationIdToWirelessChannel;
     WirelessChannel getWirelessChannelOfBasestation(uint8_t serialId) const;
 
     // Updating the basestation selection
-    void askChannelOfBasestationsWithUnknownChannel();
     bool shouldUpdateBasestationSelection;
     std::thread basestationSelectionUpdaterThread;
     void updateBasestationSelection();
-    std::vector<std::shared_ptr<Basestation>> getUnselectedBasestations() const;
 
-    bool trySelectBasestationOfColor(utils::TeamColor color);
-    void selectBasestationOfColor(std::shared_ptr<Basestation> basestation, utils::TeamColor color);
-    void unselectBasestationOfColor(utils::TeamColor color);
+    void askChannelOfBasestationsWithUnknownChannel();
+    // Gets list of basestations that could be selected as the blue or yellow basestation
+    std::vector<std::shared_ptr<Basestation>> getSelectableBasestations() const;
+    // Sends a channel change request to the given basestation to change to the given channel
+    bool sendChannelChangeRequest(std::shared_ptr<Basestation> basestation, WirelessChannel newChannel);
 
-    std::mutex messageCallbackMutex;  // Guards the messageFromBasestationCallback
+    // Will try to select for the given colors, returns the amount of basestations it selected
+    int selectBasestations(bool selectYellowBasestation, bool selectBlueBasestation);
+    bool unselectIncorrectlySelectedBasestations(); // Returns whether it unselected basestations
+
+    std::mutex messageCallbackMutex; // Guards the messageFromBasestationCallback
     void onMessageFromBasestation(const BasestationMessage& message, uint8_t serialID);
-    
-    void onMessageFromBasestation(const BasestationMessage& message, utils::TeamColor color);
     std::function<void(const BasestationMessage&, utils::TeamColor color)> messageFromBasestationCallback;
 
     static WirelessChannel getWirelessChannelCorrespondingTeamColor(utils::TeamColor color);

--- a/include/basestation/BasestationCollection.hpp
+++ b/include/basestation/BasestationCollection.hpp
@@ -5,11 +5,11 @@
 
 #include <basestation/Basestation.hpp>
 #include <functional>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <thread>
 #include <vector>
-#include <map>
 
 namespace rtt::robothub::basestation {
 
@@ -20,10 +20,10 @@ enum class WirelessChannel : unsigned int { YELLOW_CHANNEL = 0, BLUE_CHANNEL = 1
 enum class WantedBasestations { ONLY_YELLOW, ONLY_BLUE, YELLOW_AND_BLUE, NEITHER_YELLOW_NOR_BLUE };
 
 typedef struct BasestationCollectionStatus {
-   WantedBasestations wantedBasestations;
-   bool hasYellowBasestation;
-   bool hasBlueBasestation;
-   int amountOfBasestations;
+    WantedBasestations wantedBasestations;
+    bool hasYellowBasestation;
+    bool hasBlueBasestation;
+    int amountOfBasestations;
 } BasestationCollectionStatus;
 
 /* This class will take any collection of basestations, and will pick two basestations that
@@ -48,21 +48,21 @@ class BasestationCollection {
 
    private:
     // Collection and selection of basestations
-    mutable std::mutex basestationsMutex; // Guards the basestations vector
-    std::vector<std::shared_ptr<Basestation>> basestations; // All basestations
+    mutable std::mutex basestationsMutex;                    // Guards the basestations vector
+    std::vector<std::shared_ptr<Basestation>> basestations;  // All basestations
     std::vector<std::shared_ptr<Basestation>> getAllBasestations() const;
 
-    mutable std::mutex basestationSelectionMutex; // Guards both selected basestations
-    std::shared_ptr<Basestation> yellowBasestation; // Basestation selected for yellow team
-    std::shared_ptr<Basestation> blueBasestation; // Basestation selected for blue team
+    mutable std::mutex basestationSelectionMutex;    // Guards both selected basestations
+    std::shared_ptr<Basestation> yellowBasestation;  // Basestation selected for yellow team
+    std::shared_ptr<Basestation> blueBasestation;    // Basestation selected for blue team
 
     std::shared_ptr<Basestation> getSelectedBasestation(utils::TeamColor colorOfBasestation) const;
     void setSelectedBasestation(std::shared_ptr<Basestation> newBasestation, utils::TeamColor color);
 
     // Keeps track of which basestation has which wireless channel
     std::map<const BasestationIdentifier, WirelessChannel> basestationIdToChannel;
-    mutable std::mutex basestationIdToChannelMutex; // Guards the basestationIdToChannel map
-    
+    mutable std::mutex basestationIdToChannelMutex;  // Guards the basestationIdToChannel map
+
     WirelessChannel getChannelOfBasestation(const BasestationIdentifier& basestationId) const;
     void setChannelOfBasestation(const BasestationIdentifier& basestationId, WirelessChannel newChannel);
     void removeBasestationIdToChannelEntry(const BasestationIdentifier& basestationId);
@@ -88,12 +88,12 @@ class BasestationCollection {
     // Sends a channel change request to the given basestation to change to the given channel
     bool sendChannelChangeRequest(const std::shared_ptr<Basestation>& basestation, WirelessChannel newChannel);
 
-    int unselectUnwantedBasestations(); // Unselect basestations that are not used
-    int unselectIncorrectlySelectedBasestations(); // Unselect basestations that have the wrong channel
-    int selectWantedBasestations(); // Select basestations that we need
-    int selectBasestations(bool selectYellowBasestation, bool selectBlueBasestation); // Will try to select the given basestations
+    int unselectUnwantedBasestations();                                                // Unselect basestations that are not used
+    int unselectIncorrectlySelectedBasestations();                                     // Unselect basestations that have the wrong channel
+    int selectWantedBasestations();                                                    // Select basestations that we need
+    int selectBasestations(bool selectYellowBasestation, bool selectBlueBasestation);  // Will try to select the given basestations
 
-    std::mutex messageCallbackMutex; // Guards the messageFromBasestationCallback
+    std::mutex messageCallbackMutex;  // Guards the messageFromBasestationCallback
     void onMessageFromBasestation(const BasestationMessage& message, const BasestationIdentifier& basestationId);
     std::function<void(const BasestationMessage&, utils::TeamColor color)> messageFromBasestationCallback;
 

--- a/include/basestation/BasestationCollection.hpp
+++ b/include/basestation/BasestationCollection.hpp
@@ -37,8 +37,8 @@ class BasestationCollection {
     // This function makes sure the collection is up to date. Call this function frequently
     void updateBasestationCollection(const std::vector<libusb_device*>& pluggedBasestationDevices);
 
-    // Sends a message to the basestation of the given team. Returns success
-    bool sendMessageToBasestation(BasestationMessage& message, utils::TeamColor teamColor);
+    // Sends a message to the basestation of the given team. Returns bytes sent, -1 if error
+    int sendMessageToBasestation(BasestationMessage& message, utils::TeamColor teamColor);
 
     // Set a callback function to receive all messages from the two basestations of the teams
     void setIncomingMessageCallback(std::function<void(const BasestationMessage&, utils::TeamColor)> callback);

--- a/include/basestation/BasestationCollection.hpp
+++ b/include/basestation/BasestationCollection.hpp
@@ -34,18 +34,28 @@ class BasestationCollection {
     void setIncomingMessageCallback(std::function<void(const BasestationMessage&, utils::TeamColor)> callback);
 
     // Prints the current status of the collection directly to the console
-    void printCollection() const;
+    void printCollection();
 
    private:
     // Collection and selection of basestations
+    std::mutex basestationsMutex; // Guards the basestations vector
     std::vector<std::shared_ptr<Basestation>> basestations; // All basestations
+    std::vector<std::shared_ptr<Basestation>> getAllBasestations();
+
+    std::mutex basestationSelectionMutex; // Guards both selected basestations
     std::shared_ptr<Basestation> yellowBasestation; // Basestation selected for yellow team
     std::shared_ptr<Basestation> blueBasestation; // Basestation selected for blue team
-    // TODO: Make basestations and yellow and blue basestation thread safe
+
+    std::shared_ptr<Basestation> getSelectedBasestation(utils::TeamColor colorOfBasestation);
+    void setSelectedBasestation(std::shared_ptr<Basestation> newBasestation, utils::TeamColor color);
 
     // Keeps track of which basestation has which wireless channel
-    std::map<uint8_t, WirelessChannel> basestationIdToWirelessChannel;
-    WirelessChannel getWirelessChannelOfBasestation(uint8_t serialId) const;
+    std::map<uint8_t, WirelessChannel> basestationIdToChannel;
+    std::mutex basestationIdToChannelMutex; // Guards the basestationIdToChannel map
+    
+    WirelessChannel getChannelOfBasestation(uint8_t serialId);
+    void setChannelOfBasestation(uint8_t serialId, WirelessChannel newChannel);
+    void removeBasestationIdToChannelEntry(uint8_t serialId);
 
     // Updating the basestation selection
     bool shouldUpdateBasestationSelection;
@@ -56,7 +66,7 @@ class BasestationCollection {
 
     void askChannelOfBasestationsWithUnknownChannel();
     // Gets list of basestations that could be selected as the blue or yellow basestation
-    std::vector<std::shared_ptr<Basestation>> getSelectableBasestations() const;
+    std::vector<std::shared_ptr<Basestation>> getSelectableBasestations();
     // Sends a channel change request to the given basestation to change to the given channel
     bool sendChannelChangeRequest(std::shared_ptr<Basestation> basestation, WirelessChannel newChannel);
 

--- a/include/basestation/BasestationCollection.hpp
+++ b/include/basestation/BasestationCollection.hpp
@@ -50,12 +50,12 @@ class BasestationCollection {
     void setSelectedBasestation(std::shared_ptr<Basestation> newBasestation, utils::TeamColor color);
 
     // Keeps track of which basestation has which wireless channel
-    std::map<uint8_t, WirelessChannel> basestationIdToChannel;
+    std::map<const BasestationIdentifier&, WirelessChannel> basestationIdToChannel;
     std::mutex basestationIdToChannelMutex; // Guards the basestationIdToChannel map
     
-    WirelessChannel getChannelOfBasestation(uint8_t serialId);
-    void setChannelOfBasestation(uint8_t serialId, WirelessChannel newChannel);
-    void removeBasestationIdToChannelEntry(uint8_t serialId);
+    WirelessChannel getChannelOfBasestation(const BasestationIdentifier& basestationId);
+    void setChannelOfBasestation(const BasestationIdentifier& basestationId, WirelessChannel newChannel);
+    void removeBasestationIdToChannelEntry(const BasestationIdentifier& basestationId);
 
     // Updating the basestation selection
     bool shouldUpdateBasestationSelection;
@@ -75,7 +75,7 @@ class BasestationCollection {
     bool unselectIncorrectlySelectedBasestations(); // Returns whether it unselected basestations
 
     std::mutex messageCallbackMutex; // Guards the messageFromBasestationCallback
-    void onMessageFromBasestation(const BasestationMessage& message, uint8_t serialID);
+    void onMessageFromBasestation(const BasestationMessage& message, const BasestationIdentifier& basestationId);
     std::function<void(const BasestationMessage&, utils::TeamColor color)> messageFromBasestationCallback;
 
     static WirelessChannel getWirelessChannelCorrespondingTeamColor(utils::TeamColor color);

--- a/include/basestation/BasestationCollection.hpp
+++ b/include/basestation/BasestationCollection.hpp
@@ -51,6 +51,8 @@ class BasestationCollection {
     bool shouldUpdateBasestationSelection;
     std::thread basestationSelectionUpdaterThread;
     void updateBasestationSelection();
+    void removeOldBasestations(const std::vector<libusb_device*>& pluggedBasestationDevices);
+    void addNewBasestations(const std::vector<libusb_device*>& pluggedBasestationDevices);
 
     void askChannelOfBasestationsWithUnknownChannel();
     // Gets list of basestations that could be selected as the blue or yellow basestation

--- a/include/basestation/BasestationCollection.hpp
+++ b/include/basestation/BasestationCollection.hpp
@@ -10,7 +10,11 @@
 #include <thread>
 #include <vector>
 
+#include <map>
+
 namespace rtt::robothub::basestation {
+
+enum class WirelessChannel : unsigned int { YELLOW_CHANNEL = 0, BLUE_CHANNEL = 1, UNKNOWN = 2 };
 
 class BasestationCollection {
    public:
@@ -31,7 +35,12 @@ class BasestationCollection {
     std::shared_ptr<Basestation> blueBasestation;
     std::shared_ptr<Basestation> yellowBasestation;
 
+    // Keeps track of which basestation has which wireless channel
+    std::map<uint8_t, WirelessChannel> basestationIdToWirelessChannel;
+    WirelessChannel getWirelessChannelOfBasestation(uint8_t serialId) const;
+
     // Updating the basestation selection
+    void askChannelOfBasestationsWithUnknownChannel();
     bool shouldUpdateBasestationSelection;
     std::thread basestationSelectionUpdaterThread;
     void updateBasestationSelection();
@@ -42,6 +51,8 @@ class BasestationCollection {
     void unselectBasestationOfColor(utils::TeamColor color);
 
     std::mutex messageCallbackMutex;  // Guards the messageFromBasestationCallback
+    void onMessageFromBasestation(const BasestationMessage& message, uint8_t serialID);
+    
     void onMessageFromBasestation(const BasestationMessage& message, utils::TeamColor color);
     std::function<void(const BasestationMessage&, utils::TeamColor color)> messageFromBasestationCallback;
 
@@ -49,6 +60,12 @@ class BasestationCollection {
     static utils::TeamColor getTeamColorCorrespondingWirelessChannel(WirelessChannel channel);
     static bool basestationIsInDeviceList(std::shared_ptr<Basestation> basestation, const std::vector<libusb_device*>& devices);
     static bool deviceIsInBasestationList(libusb_device* device, const std::vector<std::shared_ptr<Basestation>>& basestations);
+
+    // Converts a WirelessChannel to a value that can be used in REM
+    static bool wirelessChannelToREMChannel(WirelessChannel channel);
+    // Converts a wireless channel value from REM to a WirelessChannel
+    static WirelessChannel remChannelToWirelessChannel(bool remChannel);
+    static std::string wirelessChannelToString(WirelessChannel channel);
 };
 
 }  // namespace rtt::robothub::basestation

--- a/include/basestation/BasestationCollection.hpp
+++ b/include/basestation/BasestationCollection.hpp
@@ -44,26 +44,26 @@ class BasestationCollection {
     void setIncomingMessageCallback(std::function<void(const BasestationMessage&, utils::TeamColor)> callback);
 
     // Prints the current status of the collection directly to the console
-    const BasestationCollectionStatus getStatus();
+    const BasestationCollectionStatus getStatus() const;
 
    private:
     // Collection and selection of basestations
-    std::mutex basestationsMutex; // Guards the basestations vector
+    mutable std::mutex basestationsMutex; // Guards the basestations vector
     std::vector<std::shared_ptr<Basestation>> basestations; // All basestations
-    std::vector<std::shared_ptr<Basestation>> getAllBasestations();
+    std::vector<std::shared_ptr<Basestation>> getAllBasestations() const;
 
-    std::mutex basestationSelectionMutex; // Guards both selected basestations
+    mutable std::mutex basestationSelectionMutex; // Guards both selected basestations
     std::shared_ptr<Basestation> yellowBasestation; // Basestation selected for yellow team
     std::shared_ptr<Basestation> blueBasestation; // Basestation selected for blue team
 
-    std::shared_ptr<Basestation> getSelectedBasestation(utils::TeamColor colorOfBasestation);
+    std::shared_ptr<Basestation> getSelectedBasestation(utils::TeamColor colorOfBasestation) const;
     void setSelectedBasestation(std::shared_ptr<Basestation> newBasestation, utils::TeamColor color);
 
     // Keeps track of which basestation has which wireless channel
     std::map<const BasestationIdentifier, WirelessChannel> basestationIdToChannel;
-    std::mutex basestationIdToChannelMutex; // Guards the basestationIdToChannel map
+    mutable std::mutex basestationIdToChannelMutex; // Guards the basestationIdToChannel map
     
-    WirelessChannel getChannelOfBasestation(const BasestationIdentifier& basestationId);
+    WirelessChannel getChannelOfBasestation(const BasestationIdentifier& basestationId) const;
     void setChannelOfBasestation(const BasestationIdentifier& basestationId, WirelessChannel newChannel);
     void removeBasestationIdToChannelEntry(const BasestationIdentifier& basestationId);
 
@@ -82,11 +82,11 @@ class BasestationCollection {
     void removeOldBasestations(const std::vector<libusb_device*>& pluggedBasestationDevices);
     void addNewBasestations(const std::vector<libusb_device*>& pluggedBasestationDevices);
 
-    void askChannelOfBasestationsWithUnknownChannel();
+    void askChannelOfBasestationsWithUnknownChannel() const;
     // Gets list of basestations that could be selected as the blue or yellow basestation
-    std::vector<std::shared_ptr<Basestation>> getSelectableBasestations();
+    std::vector<std::shared_ptr<Basestation>> getSelectableBasestations() const;
     // Sends a channel change request to the given basestation to change to the given channel
-    bool sendChannelChangeRequest(std::shared_ptr<Basestation> basestation, WirelessChannel newChannel);
+    bool sendChannelChangeRequest(const std::shared_ptr<Basestation>& basestation, WirelessChannel newChannel);
 
     int unselectUnwantedBasestations(); // Unselect basestations that are not used
     int unselectIncorrectlySelectedBasestations(); // Unselect basestations that have the wrong channel
@@ -99,8 +99,8 @@ class BasestationCollection {
 
     static WirelessChannel getWirelessChannelCorrespondingTeamColor(utils::TeamColor color);
     static utils::TeamColor getTeamColorCorrespondingWirelessChannel(WirelessChannel channel);
-    static bool basestationIsInDeviceList(std::shared_ptr<Basestation> basestation, const std::vector<libusb_device*>& devices);
-    static bool deviceIsInBasestationList(libusb_device* device, const std::vector<std::shared_ptr<Basestation>>& basestations);
+    static bool basestationIsInDeviceList(const std::shared_ptr<Basestation>& basestation, const std::vector<libusb_device*>& devices);
+    static bool deviceIsInBasestationList(libusb_device* const device, const std::vector<std::shared_ptr<Basestation>>& basestations);
 
     // Converts a WirelessChannel to a value that can be used in REM
     static bool wirelessChannelToREMChannel(WirelessChannel channel);

--- a/include/basestation/BasestationManager.hpp
+++ b/include/basestation/BasestationManager.hpp
@@ -23,9 +23,9 @@ class BasestationManager {
     BasestationManager();
     ~BasestationManager();
 
-    bool sendRobotCommand(const RobotCommand &command, utils::TeamColor color) const;
-    bool sendRobotBuzzerCommand(const RobotBuzzer &command, utils::TeamColor color) const;
-    bool sendBasestationStatisticsRequest(utils::TeamColor color) const;
+    int sendRobotCommand(const RobotCommand &command, utils::TeamColor color) const;
+    int sendRobotBuzzerCommand(const RobotBuzzer &command, utils::TeamColor color) const;
+    int sendBasestationStatisticsRequest(utils::TeamColor color) const;
 
     void setFeedbackCallback(const std::function<void(const RobotFeedback &, utils::TeamColor color)> &callback);
 

--- a/include/basestation/BasestationManager.hpp
+++ b/include/basestation/BasestationManager.hpp
@@ -32,7 +32,7 @@ class BasestationManager {
     const BasestationManagerStatus getStatus() const;
 
    private:
-    libusb_context *usbContext;
+    libusb_context * usbContext;
 
     bool shouldListenForBasestationPlugs;
     std::thread basestationPlugsListener;
@@ -45,7 +45,7 @@ class BasestationManager {
     std::function<void(const RobotFeedback &, utils::TeamColor)> feedbackCallbackFunction;
     void callFeedbackCallback(const RobotFeedback &feedback, utils::TeamColor color) const;
 
-    static std::vector<libusb_device *> filterBasestationDevices(libusb_device **devices, int device_count);
+    static std::vector<libusb_device*> filterBasestationDevices(libusb_device *const*const devices, int device_count);
 };
 
 class FailedToInitializeLibUsb : public std::exception {

--- a/include/basestation/BasestationManager.hpp
+++ b/include/basestation/BasestationManager.hpp
@@ -32,7 +32,7 @@ class BasestationManager {
     const BasestationManagerStatus getStatus() const;
 
    private:
-    libusb_context * usbContext;
+    libusb_context *usbContext;
 
     bool shouldListenForBasestationPlugs;
     std::thread basestationPlugsListener;
@@ -45,7 +45,7 @@ class BasestationManager {
     std::function<void(const RobotFeedback &, utils::TeamColor)> feedbackCallbackFunction;
     void callFeedbackCallback(const RobotFeedback &feedback, utils::TeamColor color) const;
 
-    static std::vector<libusb_device*> filterBasestationDevices(libusb_device *const*const devices, int device_count);
+    static std::vector<libusb_device *> filterBasestationDevices(libusb_device *const *const devices, int device_count);
 };
 
 class FailedToInitializeLibUsb : public std::exception {

--- a/include/basestation/BasestationManager.hpp
+++ b/include/basestation/BasestationManager.hpp
@@ -13,6 +13,11 @@
 
 namespace rtt::robothub::basestation {
 
+// Contains the status of the basestation manager. Currently only has the status of its collection
+typedef struct BasestationManagerStatus {
+    BasestationCollectionStatus basestationCollection;
+} BasestationManagerStatus;
+
 class BasestationManager {
    public:
     BasestationManager();
@@ -24,7 +29,7 @@ class BasestationManager {
 
     void setFeedbackCallback(const std::function<void(const RobotFeedback &, utils::TeamColor color)> &callback);
 
-    void printStatus() const;
+    const BasestationManagerStatus getStatus() const;
 
    private:
     libusb_context *usbContext;

--- a/include/simulation/ConfigurationCommand.hpp
+++ b/include/simulation/ConfigurationCommand.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
 #include <ssl_simulation_control.pb.h>
+#include <utilities.h>
 
 #include <simulation/RobotProperties.hpp>
-#include <utilities.h>
 
 namespace rtt::robothub::simulation {
 /*  This class contains command information to configure and setup the simulator.

--- a/include/simulation/SimulatorManager.hpp
+++ b/include/simulation/SimulatorManager.hpp
@@ -7,14 +7,13 @@
 #include <ssl_simulation_robot_control.pb.h>
 #include <ssl_simulation_robot_feedback.pb.h>
 #include <ssl_vision_geometry.pb.h>
-
-#include <simulation/ConfigurationCommand.hpp>
-#include <simulation/Feedback.hpp>
-#include <simulation/RobotControlCommand.hpp>
 #include <utilities.h>
 
 #include <QtNetwork>
 #include <functional>
+#include <simulation/ConfigurationCommand.hpp>
+#include <simulation/Feedback.hpp>
+#include <simulation/RobotControlCommand.hpp>
 #include <stdexcept>
 #include <string>
 #include <thread>

--- a/include/utilities.h
+++ b/include/utilities.h
@@ -6,7 +6,7 @@
 
 namespace rtt::robothub::utils {
 
-enum class RobotHubMode { NEITHER, SIMULATOR, BASESTATION, BOTH };
+enum class RobotHubMode { NEITHER, SIMULATOR, BASESTATION };
 
 enum class TeamColor { YELLOW, BLUE };
 
@@ -45,8 +45,6 @@ static int char2int(char input) {
         return RobotHubMode::BASESTATION;
     } else if (type == "Simulator") {
         return RobotHubMode::SIMULATOR;
-    } else if (type == "Both") {
-        return RobotHubMode::BOTH;
     } else {
         return RobotHubMode::NEITHER;
     }
@@ -58,10 +56,10 @@ static int char2int(char input) {
             return "Basestation";
         case RobotHubMode::SIMULATOR:
             return "Simulator";
-        case RobotHubMode::BOTH:
-            return "Both";
-        default:
+        case RobotHubMode::NEITHER:
             return "Neither";
+        default:
+            return "Unknown";
     }
 }
 

--- a/src/RobotHub.cpp
+++ b/src/RobotHub.cpp
@@ -145,18 +145,16 @@ void RobotHub::sendCommandsToBasestation(const proto::AICommand &commands, utils
 
         command.feedback = false;
 
-        bool sentCommand = this->basestationManager->sendRobotCommand(command, color);
+        int bytesSent = this->basestationManager->sendRobotCommand(command, color);
 
         // Update statistics
         this->statistics.incrementCommandsReceivedCounter(command.id, color);
 
-        // Update bytes sent/packets dropped statistics
-        if (sentCommand) {
-            // TODO: Make this bytes instead of packets sent
+        if (bytesSent > 0) {
             if (color == utils::TeamColor::YELLOW) {
-                this->statistics.yellowTeamBytesSent++;
+                this->statistics.yellowTeamBytesSent += bytesSent;
             } else {
-                this->statistics.blueTeamBytesSent++;
+                this->statistics.blueTeamBytesSent += bytesSent;
             }
         } else {
             if (color == utils::TeamColor::YELLOW) {

--- a/src/RobotHub.cpp
+++ b/src/RobotHub.cpp
@@ -1,8 +1,8 @@
 #include <RobotCommand.h>
 #include <RobotHub.h>
+#include <roboteam_utils/Print.h>
 
 #include <cmath>
-#include <iostream>
 #include <sstream>
 
 namespace rtt::robothub {
@@ -177,7 +177,7 @@ void RobotHub::onRobotCommands(const proto::AICommand &commands, utils::TeamColo
             // Do not handle commands
             break;
         default:
-            std::cout << "[RobotHub]: Warning: Unknown robothub mode" << std::endl;
+            RTT_WARNING("Unknown robothub mode")
             break;
     }
 }

--- a/src/RobotHub.cpp
+++ b/src/RobotHub.cpp
@@ -308,7 +308,10 @@ std::shared_ptr<proto::WorldRobot> getWorldBot(unsigned int id, utils::TeamColor
     return nullptr;
 }
 
-bool RobotHub::sendRobotFeedback(const proto::RobotData &feedback) const { return this->robotFeedbackPublisher->publish(feedback); }
+bool RobotHub::sendRobotFeedback(const proto::RobotData &feedback) {
+    this->statistics.feedbackBytesSent += (int) feedback.ByteSizeLong();
+    return this->robotFeedbackPublisher->publish(feedback);
+}
 
 const char *FailedToInitializeNetworkersException::what() const throw() { return "Failed to initialize networker(s). Is another RobotHub running?"; }
 

--- a/src/RobotHub.cpp
+++ b/src/RobotHub.cpp
@@ -33,9 +33,13 @@ RobotHub::RobotHub() {
     this->basestationManager->setFeedbackCallback([&](const RobotFeedback &feedback, utils::TeamColor color) { this->handleRobotFeedbackFromBasestation(feedback, color); });
 }
 
-RobotHubStatistics& RobotHub::getStatistics() {
+const RobotHubStatistics& RobotHub::getStatistics() {
     this->statistics.basestationManagerStatus = this->basestationManager->getStatus();
     return this->statistics;
+}
+
+void RobotHub::resetStatistics() {
+    this->statistics.resetValues();
 }
 
 bool RobotHub::initializeNetworkers() {
@@ -335,7 +339,7 @@ std::shared_ptr<proto::WorldRobot> getWorldBot(unsigned int id, utils::TeamColor
     return nullptr;
 }
 
-bool RobotHub::sendRobotFeedback(const proto::RobotData &feedback) { return this->robotFeedbackPublisher->publish(feedback); }
+bool RobotHub::sendRobotFeedback(const proto::RobotData &feedback) const { return this->robotFeedbackPublisher->publish(feedback); }
 
 const char *FailedToInitializeNetworkersException::what() const throw() { return "Failed to initialize networker(s). Is another RobotHub running?"; }
 
@@ -346,8 +350,7 @@ int main(int argc, char *argv[]) {
 
     while (true) {
         std::this_thread::sleep_for(std::chrono::seconds(1));
-        auto& statistics = app.getStatistics();
-        statistics.print();
-        statistics.resetValues();
+        app.getStatistics().print();
+        app.resetStatistics();
     }
 }

--- a/src/RobotHubStatistics.cpp
+++ b/src/RobotHubStatistics.cpp
@@ -1,7 +1,8 @@
+#include <roboteam_utils/Print.h>
+
 #include <RobotHubStatistics.hpp>
 #include <chrono>
 #include <sstream>
-#include <roboteam_utils/Print.h>
 
 namespace rtt::robothub {
 

--- a/src/RobotHubStatistics.cpp
+++ b/src/RobotHubStatistics.cpp
@@ -1,7 +1,7 @@
 #include <RobotHubStatistics.hpp>
+#include <chrono>
 #include <iostream>
 #include <sstream>
-#include <chrono>
 
 namespace rtt::robothub {
 
@@ -13,7 +13,7 @@ RobotHubStatistics::RobotHubStatistics() {
     this->yellowFeedbackReceived.fill(0);
     this->blueCommandsSent.fill(0);
     this->blueFeedbackReceived.fill(0);
-    
+
     this->yellowTeamBytesSent = 0;
     this->blueTeamBytesSent = 0;
     this->feedbackBytesSent = 0;
@@ -37,8 +37,8 @@ void RobotHubStatistics::resetValues() {
 }
 
 void RobotHubStatistics::print() const {
-    std::array<std::string, MAX_ROBOT_STATISTICS> y; // Contains the strings for yellow robots
-    std::array<std::string, MAX_ROBOT_STATISTICS> b; // Contains the strings for blue robots
+    std::array<std::string, MAX_ROBOT_STATISTICS> y;  // Contains the strings for yellow robots
+    std::array<std::string, MAX_ROBOT_STATISTICS> b;  // Contains the strings for blue robots
 
     for (int i = 0; i < MAX_ROBOT_STATISTICS; ++i) {
         y[i] = getRobotStats(i, utils::TeamColor::YELLOW);
@@ -50,20 +50,20 @@ void RobotHubStatistics::print() const {
     ss << "                          ┏━━━━━━━━━━━━━━━━━━━┓                           " << std::endl
        << "┏━━━━━━━━━━━━━━━━━━━━━━━━━┫ Roboteam RobotHub ┣━━━┳━━━━━━━━━━━━━━━━━━━━━━┓" << std::endl
        << "┃                         ┗━━━━━━━━━━━━━━━━━━━┛   ┃                      ┃" << std::endl
-       << "┃ Mode: "<<this->getRobotHubMode()<<"          "<<this->getRunTime()<<" ┃     Basestations     ┃" << std::endl
-         << "┃                                                 ┃ Connected: "<<this->getAmountOfBasestations()<<" ┃" << std::endl
-         << "┃ Incoming data: (id: commands, feedbacks)        ┃ Wanted:    "<<this->getWantedBasestations()  <<" ┃" << std::endl
-         << "┃ Yellow team:                                    ┃ Selected:  "<<this->getSelectedBasestations()<<" ┃" << std::endl
-       << "┃"<<y[0]<<" │"<<y[4]<<" │ " <<y[8]<<" │ "<<y[12]<<" ┣━━━━━━━━━━━━━━━━━━━━━━┫" << std::endl
-       << "┃"<<y[1]<<" │"<<y[5]<<" │ " <<y[9]<<" │ "<<y[13]<<" ┃      Bytes sent      ┃" << std::endl
-       << "┃"<<y[2]<<" │"<<y[6]<<" │ "<<y[10]<<" │ "<<y[14]<<" ┃ Yellow team: "<<this->numberToSideBox(this->yellowTeamBytesSent)<<" ┃" << std::endl
-       << "┃"<<y[3]<<" │"<<y[7]<<" │ "<<y[11]<<" │ "<<y[15]<<" ┃ Blue team:   "<<this->numberToSideBox(this->blueTeamBytesSent)  <<" ┃" << std::endl
-         << "┃                                                 ┃ Feedback:    "<<this->numberToSideBox(this->feedbackBytesSent)  <<" ┃" << std::endl
-         << "┃ Blue team:                                      ┣━━━━━━━━━━━━━━━━━━━━━━┫" << std::endl
-       << "┃"<<b[0]<<" │"<<b[4]<<" │ " <<b[8]<<" │ "<<b[12]<<" ┃    Packets dropped   ┃" << std::endl
-       << "┃"<<b[1]<<" │"<<b[5]<<" │ " <<b[9]<<" │ "<<b[13]<<" ┃ Yellow team: "<<this->numberToSideBox(this->yellowTeamPacketsDropped)<<" ┃" << std::endl
-       << "┃"<<b[2]<<" │"<<b[6]<<" │ "<<b[10]<<" │ "<<b[14]<<" ┃ Blue team:   "<<this->numberToSideBox(this->blueTeamPacketsDropped)  <<" ┃" << std::endl
-       << "┃"<<b[3]<<" │"<<b[7]<<" │ "<<b[11]<<" │ "<<b[15]<<" ┃ Feedback:    "<<this->numberToSideBox(this->feedbackPacketsDropped)  <<" ┃" << std::endl
+       << "┃ Mode: " << this->getRobotHubMode() << "          " << this->getRunTime() << " ┃     Basestations     ┃" << std::endl
+       << "┃                                                 ┃ Connected: " << this->getAmountOfBasestations() << " ┃" << std::endl
+       << "┃ Incoming data: (id: commands, feedbacks)        ┃ Wanted:    " << this->getWantedBasestations() << " ┃" << std::endl
+       << "┃ Yellow team:                                    ┃ Selected:  " << this->getSelectedBasestations() << " ┃" << std::endl
+       << "┃" << y[0] << " │" << y[4] << " │ " << y[8] << " │ " << y[12] << " ┣━━━━━━━━━━━━━━━━━━━━━━┫" << std::endl
+       << "┃" << y[1] << " │" << y[5] << " │ " << y[9] << " │ " << y[13] << " ┃      Bytes sent      ┃" << std::endl
+       << "┃" << y[2] << " │" << y[6] << " │ " << y[10] << " │ " << y[14] << " ┃ Yellow team: " << this->numberToSideBox(this->yellowTeamBytesSent) << " ┃" << std::endl
+       << "┃" << y[3] << " │" << y[7] << " │ " << y[11] << " │ " << y[15] << " ┃ Blue team:   " << this->numberToSideBox(this->blueTeamBytesSent) << " ┃" << std::endl
+       << "┃                                                 ┃ Feedback:    " << this->numberToSideBox(this->feedbackBytesSent) << " ┃" << std::endl
+       << "┃ Blue team:                                      ┣━━━━━━━━━━━━━━━━━━━━━━┫" << std::endl
+       << "┃" << b[0] << " │" << b[4] << " │ " << b[8] << " │ " << b[12] << " ┃    Packets dropped   ┃" << std::endl
+       << "┃" << b[1] << " │" << b[5] << " │ " << b[9] << " │ " << b[13] << " ┃ Yellow team: " << this->numberToSideBox(this->yellowTeamPacketsDropped) << " ┃" << std::endl
+       << "┃" << b[2] << " │" << b[6] << " │ " << b[10] << " │ " << b[14] << " ┃ Blue team:   " << this->numberToSideBox(this->blueTeamPacketsDropped) << " ┃" << std::endl
+       << "┃" << b[3] << " │" << b[7] << " │ " << b[11] << " │ " << b[15] << " ┃ Feedback:    " << this->numberToSideBox(this->feedbackPacketsDropped) << " ┃" << std::endl
        << "┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━━━━━━━┛" << std::endl;
 
     std::cout << ss.str();
@@ -100,9 +100,9 @@ std::string RobotHubStatistics::getRunTime() const {
     auto now = std::chrono::steady_clock::now();
     int64_t runTime = std::chrono::duration_cast<std::chrono::seconds>(now - this->startTime).count();
 
-    int hours = (int) (runTime / 3600);
-    int minutes = (int) ((runTime % 3600) / 60);
-    int seconds = (int) (runTime % 60);
+    int hours = (int)(runTime / 3600);
+    int minutes = (int)((runTime % 3600) / 60);
+    int seconds = (int)(runTime % 60);
 
     std::string time;
 
@@ -148,9 +148,7 @@ std::string RobotHubStatistics::getSelectedBasestations() const {
 
     return RobotHubStatistics::string_format("%-9s", basestations.c_str());
 }
-std::string RobotHubStatistics::numberToSideBox(int n) const {
-    return RobotHubStatistics::string_format("%7d", n);
-}
+std::string RobotHubStatistics::numberToSideBox(int n) const { return RobotHubStatistics::string_format("%7d", n); }
 
 std::string RobotHubStatistics::wantedBasestationsToString(basestation::WantedBasestations wantedBasestations) {
     std::string text;
@@ -174,15 +172,16 @@ std::string RobotHubStatistics::wantedBasestationsToString(basestation::WantedBa
     return text;
 }
 
-template<typename ... Args>
-std::string RobotHubStatistics::string_format( const std::string& format, Args ... args )
-{
-    int size_s = std::snprintf( nullptr, 0, format.c_str(), args ... ) + 1; // Extra space for '\0'
-    if( size_s <= 0 ){ throw std::runtime_error( "Error during formatting." ); }
-    auto size = static_cast<size_t>( size_s );
-    auto buf = std::make_unique<char[]>( size );
-    std::snprintf( buf.get(), size, format.c_str(), args ... );
-    return std::string( buf.get(), buf.get() + size - 1 ); // We don't want the '\0' inside
+template <typename... Args>
+std::string RobotHubStatistics::string_format(const std::string& format, Args... args) {
+    int size_s = std::snprintf(nullptr, 0, format.c_str(), args...) + 1;  // Extra space for '\0'
+    if (size_s <= 0) {
+        throw std::runtime_error("Error during formatting.");
+    }
+    auto size = static_cast<size_t>(size_s);
+    auto buf = std::make_unique<char[]>(size);
+    std::snprintf(buf.get(), size, format.c_str(), args...);
+    return std::string(buf.get(), buf.get() + size - 1);  // We don't want the '\0' inside
 }
 
-} // namespace rtt::robothub
+}  // namespace rtt::robothub

--- a/src/RobotHubStatistics.cpp
+++ b/src/RobotHubStatistics.cpp
@@ -1,0 +1,188 @@
+#include <RobotHubStatistics.hpp>
+#include <iostream>
+#include <sstream>
+#include <chrono>
+
+namespace rtt::robothub {
+
+RobotHubStatistics::RobotHubStatistics() {
+    this->startTime = std::chrono::steady_clock::now();
+
+    // Fill arrays with 0
+    this->yellowCommandsSent.fill(0);
+    this->yellowFeedbackReceived.fill(0);
+    this->blueCommandsSent.fill(0);
+    this->blueFeedbackReceived.fill(0);
+    
+    this->yellowTeamBytesSent = 0;
+    this->blueTeamBytesSent = 0;
+    this->feedbackBytesSent = 0;
+    this->yellowTeamPacketsDropped = 0;
+    this->blueTeamPacketsDropped = 0;
+    this->feedbackPacketsDropped = 0;
+}
+
+void RobotHubStatistics::resetValues() {
+    this->yellowCommandsSent.fill(0);
+    this->yellowFeedbackReceived.fill(0);
+    this->blueCommandsSent.fill(0);
+    this->blueFeedbackReceived.fill(0);
+
+    this->yellowTeamBytesSent = 0;
+    this->blueTeamBytesSent = 0;
+    this->feedbackBytesSent = 0;
+    this->yellowTeamPacketsDropped = 0;
+    this->blueTeamPacketsDropped = 0;
+    this->feedbackPacketsDropped = 0;
+}
+
+void RobotHubStatistics::print() {
+    std::array<std::string, MAX_ROBOT_STATISTICS> y; // Contains the strings for yellow robots
+    std::array<std::string, MAX_ROBOT_STATISTICS> b; // Contains the strings for blue robots
+
+    for (int i = 0; i < MAX_ROBOT_STATISTICS; ++i) {
+        y[i] = getRobotStats(i, utils::TeamColor::YELLOW);
+        b[i] = getRobotStats(i, utils::TeamColor::BLUE);
+    }
+
+    std::stringstream ss;
+
+    ss << "                          ┏━━━━━━━━━━━━━━━━━━━┓                           " << std::endl
+       << "┏━━━━━━━━━━━━━━━━━━━━━━━━━┫ Roboteam RobotHub ┣━━━┳━━━━━━━━━━━━━━━━━━━━━━┓" << std::endl
+       << "┃                         ┗━━━━━━━━━━━━━━━━━━━┛   ┃                      ┃" << std::endl
+       << "┃ Mode: "<<this->getRobotHubMode()<<"          "<<this->getRunTime()<<" ┃     Basestations     ┃" << std::endl
+         << "┃                                                 ┃ Connected: "<<this->getAmountOfBasestations()<<" ┃" << std::endl
+         << "┃ Incoming data: (id: commands, feedbacks)        ┃ Wanted:    "<<this->getWantedBasestations()  <<" ┃" << std::endl
+         << "┃ Yellow team:                                    ┃ Selected:  "<<this->getSelectedBasestations()<<" ┃" << std::endl
+       << "┃"<<y[0]<<" │"<<y[4]<<" │ " <<y[8]<<" │ "<<y[12]<<" ┣━━━━━━━━━━━━━━━━━━━━━━┫" << std::endl
+       << "┃"<<y[1]<<" │"<<y[5]<<" │ " <<y[9]<<" │ "<<y[13]<<" ┃      Bytes sent      ┃" << std::endl
+       << "┃"<<y[2]<<" │"<<y[6]<<" │ "<<y[10]<<" │ "<<y[14]<<" ┃ Yellow team: "<<this->numberToSideBox(this->yellowTeamBytesSent)<<" ┃" << std::endl
+       << "┃"<<y[3]<<" │"<<y[7]<<" │ "<<y[11]<<" │ "<<y[15]<<" ┃ Blue team:   "<<this->numberToSideBox(this->blueTeamBytesSent)  <<" ┃" << std::endl
+         << "┃                                                 ┃ Feedback:    "<<this->numberToSideBox(this->feedbackBytesSent)  <<" ┃" << std::endl
+         << "┃ Blue team:                                      ┣━━━━━━━━━━━━━━━━━━━━━━┫" << std::endl
+       << "┃"<<b[0]<<" │"<<b[4]<<" │ " <<b[8]<<" │ "<<b[12]<<" ┃    Packets dropped   ┃" << std::endl
+       << "┃"<<b[1]<<" │"<<b[5]<<" │ " <<b[9]<<" │ "<<b[13]<<" ┃ Yellow team: "<<this->numberToSideBox(this->yellowTeamPacketsDropped)<<" ┃" << std::endl
+       << "┃"<<b[2]<<" │"<<b[6]<<" │ "<<b[10]<<" │ "<<b[14]<<" ┃ Blue team:   "<<this->numberToSideBox(this->blueTeamPacketsDropped)  <<" ┃" << std::endl
+       << "┃"<<b[3]<<" │"<<b[7]<<" │ "<<b[11]<<" │ "<<b[15]<<" ┃ Feedback:    "<<this->numberToSideBox(this->feedbackPacketsDropped)  <<" ┃" << std::endl
+       << "┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━━━━━━━┛" << std::endl;
+
+    std::cout << ss.str();
+}
+
+void RobotHubStatistics::incrementCommandsReceivedCounter(int id, utils::TeamColor color) {
+    auto& arrayToIncrement = color == utils::TeamColor::YELLOW ? this->yellowCommandsSent : this->blueCommandsSent;
+    arrayToIncrement[id]++;
+}
+void RobotHubStatistics::incrementFeedbackReceivedCounter(int id, utils::TeamColor color) {
+    auto& arrayToIncrement = color == utils::TeamColor::YELLOW ? this->yellowFeedbackReceived : this->blueFeedbackReceived;
+    arrayToIncrement[id]++;
+}
+
+std::string RobotHubStatistics::getRobotStats(int robotId, utils::TeamColor team) const {
+    std::string stats;
+
+    switch (team) {
+        case utils::TeamColor::BLUE:
+            stats = RobotHubStatistics::string_format("%2d: %2d, %2d", robotId, this->blueCommandsSent[robotId], this->blueFeedbackReceived[robotId]);
+            break;
+        case utils::TeamColor::YELLOW:
+            stats = RobotHubStatistics::string_format("%2d: %2d, %2d", robotId, this->yellowCommandsSent[robotId], this->yellowFeedbackReceived[robotId]);
+            break;
+        default:
+            stats = RobotHubStatistics::string_format("%2d:  ?,  ?", robotId);
+            break;
+    }
+
+    return stats;
+}
+
+std::string RobotHubStatistics::getRunTime() {
+    auto now = std::chrono::steady_clock::now();
+    int64_t runTime = std::chrono::duration_cast<std::chrono::seconds>(now - this->startTime).count();
+
+    int hours = (int) (runTime / 3600);
+    int minutes = (int) ((runTime % 3600) / 60);
+    int seconds = (int) (runTime % 60);
+
+    std::string time;
+
+    if (hours > 0) {
+        time = RobotHubStatistics::string_format("Running: %2dh %2dm %2ds", hours, minutes, seconds);
+    } else if (minutes > 0) {
+        time = RobotHubStatistics::string_format("Running: %2dm %2ds", minutes, seconds);
+    } else {
+        time = RobotHubStatistics::string_format("Running: %2ds", seconds);
+    }
+
+    std::string text = RobotHubStatistics::string_format("%20s", time.c_str());
+
+    return text;
+}
+
+std::string RobotHubStatistics::getRobotHubMode() {
+    std::string mode = utils::modeToString(this->robotHubMode);
+    std::string text = RobotHubStatistics::string_format("%-11s", mode.c_str());
+    return text;
+}
+
+std::string RobotHubStatistics::getAmountOfBasestations() {
+    return RobotHubStatistics::string_format("%-9d", this->basestationManagerStatus.basestationCollection.amountOfBasestations);
+}
+
+std::string RobotHubStatistics::getWantedBasestations() {
+    std::string basestations = wantedBasestationsToString(this->basestationManagerStatus.basestationCollection.wantedBasestations);
+    return RobotHubStatistics::string_format("%-9s", basestations.c_str());
+}
+std::string RobotHubStatistics::getSelectedBasestations() {
+    std::string basestations;
+
+    if (this->basestationManagerStatus.basestationCollection.hasYellowBasestation && this->basestationManagerStatus.basestationCollection.hasBlueBasestation) {
+        basestations = wantedBasestationsToString(basestation::WantedBasestations::YELLOW_AND_BLUE);
+    } else if (this->basestationManagerStatus.basestationCollection.hasYellowBasestation) {
+        basestations = wantedBasestationsToString(basestation::WantedBasestations::ONLY_YELLOW);
+    } else if (this->basestationManagerStatus.basestationCollection.hasBlueBasestation) {
+        basestations = wantedBasestationsToString(basestation::WantedBasestations::ONLY_BLUE);
+    } else {
+        basestations = wantedBasestationsToString(basestation::WantedBasestations::NEITHER_YELLOW_NOR_BLUE);
+    }
+
+    return RobotHubStatistics::string_format("%-9s", basestations.c_str());
+}
+std::string RobotHubStatistics::numberToSideBox(int n) {
+    return RobotHubStatistics::string_format("%7d", n);
+}
+
+std::string RobotHubStatistics::wantedBasestationsToString(basestation::WantedBasestations wantedBasestations) {
+    std::string text;
+    switch (wantedBasestations) {
+        case basestation::WantedBasestations::ONLY_YELLOW:
+            text = "Yellow";
+            break;
+        case basestation::WantedBasestations::ONLY_BLUE:
+            text = "Blue";
+            break;
+        case basestation::WantedBasestations::YELLOW_AND_BLUE:
+            text = "Both";
+            break;
+        case basestation::WantedBasestations::NEITHER_YELLOW_NOR_BLUE:
+            text = "Neither";
+            break;
+        default:
+            text = "Unknown";
+            break;
+    }
+    return text;
+}
+
+template<typename ... Args>
+std::string RobotHubStatistics::string_format( const std::string& format, Args ... args )
+{
+    int size_s = std::snprintf( nullptr, 0, format.c_str(), args ... ) + 1; // Extra space for '\0'
+    if( size_s <= 0 ){ throw std::runtime_error( "Error during formatting." ); }
+    auto size = static_cast<size_t>( size_s );
+    auto buf = std::make_unique<char[]>( size );
+    std::snprintf( buf.get(), size, format.c_str(), args ... );
+    return std::string( buf.get(), buf.get() + size - 1 ); // We don't want the '\0' inside
+}
+
+} // namespace rtt::robothub

--- a/src/RobotHubStatistics.cpp
+++ b/src/RobotHubStatistics.cpp
@@ -1,7 +1,7 @@
 #include <RobotHubStatistics.hpp>
 #include <chrono>
-#include <iostream>
 #include <sstream>
+#include <roboteam_utils/Print.h>
 
 namespace rtt::robothub {
 
@@ -66,7 +66,7 @@ void RobotHubStatistics::print() const {
        << "┃" << b[3] << " │" << b[7] << " │ " << b[11] << " │ " << b[15] << " ┃ Feedback:    " << this->numberToSideBox(this->feedbackPacketsDropped) << " ┃" << std::endl
        << "┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━━━━━━━┛" << std::endl;
 
-    std::cout << ss.str();
+    RTT_INFO("\n", ss.str())
 }
 
 void RobotHubStatistics::incrementCommandsReceivedCounter(int id, utils::TeamColor color) {

--- a/src/RobotHubStatistics.cpp
+++ b/src/RobotHubStatistics.cpp
@@ -36,7 +36,7 @@ void RobotHubStatistics::resetValues() {
     this->feedbackPacketsDropped = 0;
 }
 
-void RobotHubStatistics::print() {
+void RobotHubStatistics::print() const {
     std::array<std::string, MAX_ROBOT_STATISTICS> y; // Contains the strings for yellow robots
     std::array<std::string, MAX_ROBOT_STATISTICS> b; // Contains the strings for blue robots
 
@@ -96,7 +96,7 @@ std::string RobotHubStatistics::getRobotStats(int robotId, utils::TeamColor team
     return stats;
 }
 
-std::string RobotHubStatistics::getRunTime() {
+std::string RobotHubStatistics::getRunTime() const {
     auto now = std::chrono::steady_clock::now();
     int64_t runTime = std::chrono::duration_cast<std::chrono::seconds>(now - this->startTime).count();
 
@@ -119,21 +119,21 @@ std::string RobotHubStatistics::getRunTime() {
     return text;
 }
 
-std::string RobotHubStatistics::getRobotHubMode() {
+std::string RobotHubStatistics::getRobotHubMode() const {
     std::string mode = utils::modeToString(this->robotHubMode);
     std::string text = RobotHubStatistics::string_format("%-11s", mode.c_str());
     return text;
 }
 
-std::string RobotHubStatistics::getAmountOfBasestations() {
+std::string RobotHubStatistics::getAmountOfBasestations() const {
     return RobotHubStatistics::string_format("%-9d", this->basestationManagerStatus.basestationCollection.amountOfBasestations);
 }
 
-std::string RobotHubStatistics::getWantedBasestations() {
+std::string RobotHubStatistics::getWantedBasestations() const {
     std::string basestations = wantedBasestationsToString(this->basestationManagerStatus.basestationCollection.wantedBasestations);
     return RobotHubStatistics::string_format("%-9s", basestations.c_str());
 }
-std::string RobotHubStatistics::getSelectedBasestations() {
+std::string RobotHubStatistics::getSelectedBasestations() const {
     std::string basestations;
 
     if (this->basestationManagerStatus.basestationCollection.hasYellowBasestation && this->basestationManagerStatus.basestationCollection.hasBlueBasestation) {
@@ -148,7 +148,7 @@ std::string RobotHubStatistics::getSelectedBasestations() {
 
     return RobotHubStatistics::string_format("%-9s", basestations.c_str());
 }
-std::string RobotHubStatistics::numberToSideBox(int n) {
+std::string RobotHubStatistics::numberToSideBox(int n) const {
     return RobotHubStatistics::string_format("%7d", n);
 }
 

--- a/src/basestation/Basestation.cpp
+++ b/src/basestation/Basestation.cpp
@@ -1,10 +1,9 @@
 #include <basestation/LibusbUtilities.h>
+#include <roboteam_utils/Print.h>
 
 #include <basestation/Basestation.hpp>
 #include <chrono>
 #include <cstring>
-
-#include <roboteam_utils/Print.h>
 
 namespace rtt::robothub::basestation {
 

--- a/src/basestation/Basestation.cpp
+++ b/src/basestation/Basestation.cpp
@@ -27,6 +27,11 @@ bool BasestationIdentifier::operator<(const BasestationIdentifier& other) const 
         return this->usbAddress < other.usbAddress;
     }
 }
+std::string BasestationIdentifier::toString() const {
+    int address = (int) this->usbAddress;
+    int id = (int) this->serialIdentifier;
+    return "serial id: " + std::to_string(id) + ", address: " + std::to_string(address);
+}
 
 Basestation::Basestation(libusb_device* device) : device(device), identifier(getIdentifierOfDevice(device)) {
     if (!Basestation::isDeviceABasestation(device)) {
@@ -52,6 +57,8 @@ Basestation::Basestation(libusb_device* device) : device(device), identifier(get
         throw FailedToOpenDeviceException("Failed to claim interface");
     }
 
+    std::cout << "Opened basestation(" << this->identifier.toString() << ")" << std::endl;
+
     // Start listen thread for incoming messages
     this->shouldListenForIncomingMessages = true;
     this->incomingMessageListenerThread = std::thread(&Basestation::listenForIncomingMessages, this);
@@ -66,7 +73,7 @@ Basestation::~Basestation() {
 
     // Close the usb device
     libusb_close(this->deviceHandle);
-    std::cout << "Closed basestation!" << std::endl;
+    std::cout << "Closed basestation(" << this->identifier.toString() << ")" << std::endl;
 }
 
 bool Basestation::operator==(libusb_device* otherDevice) const {

--- a/src/basestation/Basestation.cpp
+++ b/src/basestation/Basestation.cpp
@@ -17,8 +17,7 @@ constexpr unsigned int TRANSFER_OUT_TIMEOUT_MS = 500;        // Timeout for writ
 constexpr unsigned int PAUSE_ON_TRANSFER_IN_ERROR_MS = 100;  // Pause every time a read fails
 
 bool BasestationIdentifier::operator==(const BasestationIdentifier& other) const {
-    return this->usbAddress == other.usbAddress
-        && this->serialIdentifier == other.serialIdentifier;
+    return this->usbAddress == other.usbAddress && this->serialIdentifier == other.serialIdentifier;
 }
 bool BasestationIdentifier::operator<(const BasestationIdentifier& other) const {
     if (this->usbAddress == other.usbAddress) {
@@ -28,8 +27,8 @@ bool BasestationIdentifier::operator<(const BasestationIdentifier& other) const 
     }
 }
 const std::string BasestationIdentifier::toString() const {
-    int address = (int) this->usbAddress;
-    int id = (int) this->serialIdentifier;
+    int address = (int)this->usbAddress;
+    int id = (int)this->serialIdentifier;
     return "serial id: " + std::to_string(id) + ", address: " + std::to_string(address);
 }
 
@@ -82,23 +81,18 @@ bool Basestation::operator==(libusb_device* otherDevice) const {
 
     return this->identifier == otherIdentifier;
 }
-bool Basestation::operator==(const BasestationIdentifier& otherBasestationIdentifier) const {
-    return this->identifier == otherBasestationIdentifier;
-}
-bool Basestation::operator==(const std::shared_ptr<Basestation>& otherBasestation) const {
-    return otherBasestation != nullptr
-        && this->identifier == otherBasestation->identifier;
-}
+bool Basestation::operator==(const BasestationIdentifier& otherBasestationIdentifier) const { return this->identifier == otherBasestationIdentifier; }
+bool Basestation::operator==(const std::shared_ptr<Basestation>& otherBasestation) const { return otherBasestation != nullptr && this->identifier == otherBasestation->identifier; }
 
 int Basestation::sendMessageToBasestation(BasestationMessage& message) const { return this->writeBasestationMessage(message); }
 
-void Basestation::setIncomingMessageCallback(const std::function<void(const BasestationMessage&, const BasestationIdentifier&)>& callback) { this->incomingMessageCallback = callback; }
-
-const BasestationIdentifier& Basestation::getIdentifier() const {
-    return this->identifier;
+void Basestation::setIncomingMessageCallback(const std::function<void(const BasestationMessage&, const BasestationIdentifier&)>& callback) {
+    this->incomingMessageCallback = callback;
 }
 
-bool Basestation::isDeviceABasestation(libusb_device * const device) {
+const BasestationIdentifier& Basestation::getIdentifier() const { return this->identifier; }
+
+bool Basestation::isDeviceABasestation(libusb_device* const device) {
     libusb_device_descriptor descriptor;
     int r = libusb_get_device_descriptor(device, &descriptor);
     if (r < 0) {
@@ -133,7 +127,8 @@ bool Basestation::readBasestationMessage(BasestationMessage& message) const {
         libusb_bulk_transfer(this->deviceHandle, TRANSFER_IN_BUFFER_ENDPOINT, message.payloadBuffer, BASESTATION_MESSAGE_BUFFER_SIZE, &message.payloadSize, TRANSFER_IN_TIMEOUT_MS);
 
     switch (error) {
-        case LIBUSB_SUCCESS: case LIBUSB_ERROR_TIMEOUT:
+        case LIBUSB_SUCCESS:
+        case LIBUSB_ERROR_TIMEOUT:
             // Either received a message correctly, or received nothing at all, so do not send any debug message
             break;
         case LIBUSB_ERROR_NO_DEVICE: {
@@ -166,10 +161,7 @@ const BasestationIdentifier Basestation::getIdentifierOfDevice(libusb_device* co
     libusb_device_descriptor deviceDescriptor = {};
     libusb_get_device_descriptor(device, &deviceDescriptor);
 
-    const BasestationIdentifier identifier = {
-        .usbAddress = libusb_get_device_address(device),
-        .serialIdentifier = deviceDescriptor.iSerialNumber
-    };
+    const BasestationIdentifier identifier = {.usbAddress = libusb_get_device_address(device), .serialIdentifier = deviceDescriptor.iSerialNumber};
 
     return identifier;
 }

--- a/src/basestation/Basestation.cpp
+++ b/src/basestation/Basestation.cpp
@@ -70,6 +70,7 @@ Basestation::~Basestation() {
         this->incomingMessageListenerThread.join();
     }
 
+    // Release the interface so other programs can claim it
     int error = libusb_release_interface(this->deviceHandle, BASESTATION_USB_INTERFACE_NUMBER);
     if (error) {
         RTT_ERROR("Failed to release interface")

--- a/src/basestation/Basestation.cpp
+++ b/src/basestation/Basestation.cpp
@@ -27,13 +27,13 @@ bool BasestationIdentifier::operator<(const BasestationIdentifier& other) const 
         return this->usbAddress < other.usbAddress;
     }
 }
-std::string BasestationIdentifier::toString() const {
+const std::string BasestationIdentifier::toString() const {
     int address = (int) this->usbAddress;
     int id = (int) this->serialIdentifier;
     return "serial id: " + std::to_string(id) + ", address: " + std::to_string(address);
 }
 
-Basestation::Basestation(libusb_device* device) : device(device), identifier(getIdentifierOfDevice(device)) {
+Basestation::Basestation(libusb_device* const device) : device(device), identifier(getIdentifierOfDevice(device)) {
     if (!Basestation::isDeviceABasestation(device)) {
         throw FailedToOpenDeviceException("Device is not a basestation");
     }
@@ -85,20 +85,20 @@ bool Basestation::operator==(libusb_device* otherDevice) const {
 bool Basestation::operator==(const BasestationIdentifier& otherBasestationIdentifier) const {
     return this->identifier == otherBasestationIdentifier;
 }
-bool Basestation::operator==(std::shared_ptr<Basestation> otherBasestation) const {
+bool Basestation::operator==(const std::shared_ptr<Basestation>& otherBasestation) const {
     return otherBasestation != nullptr
         && this->identifier == otherBasestation->identifier;
 }
 
 int Basestation::sendMessageToBasestation(BasestationMessage& message) const { return this->writeBasestationMessage(message); }
 
-void Basestation::setIncomingMessageCallback(std::function<void(const BasestationMessage&, const BasestationIdentifier&)> callback) { this->incomingMessageCallback = callback; }
+void Basestation::setIncomingMessageCallback(const std::function<void(const BasestationMessage&, const BasestationIdentifier&)>& callback) { this->incomingMessageCallback = callback; }
 
 const BasestationIdentifier& Basestation::getIdentifier() const {
     return this->identifier;
 }
 
-bool Basestation::isDeviceABasestation(libusb_device* device) {
+bool Basestation::isDeviceABasestation(libusb_device * const device) {
     libusb_device_descriptor descriptor;
     int r = libusb_get_device_descriptor(device, &descriptor);
     if (r < 0) {
@@ -162,7 +162,7 @@ int Basestation::writeBasestationMessage(BasestationMessage& message) const {
     return bytesSent;
 }
 
-const BasestationIdentifier Basestation::getIdentifierOfDevice(libusb_device* device) {
+const BasestationIdentifier Basestation::getIdentifierOfDevice(libusb_device* const device) {
     libusb_device_descriptor deviceDescriptor = {};
     libusb_get_device_descriptor(device, &deviceDescriptor);
 

--- a/src/basestation/Basestation.cpp
+++ b/src/basestation/Basestation.cpp
@@ -71,6 +71,11 @@ Basestation::~Basestation() {
         this->incomingMessageListenerThread.join();
     }
 
+    int error = libusb_release_interface(this->deviceHandle, BASESTATION_USB_INTERFACE_NUMBER);
+    if (error) {
+        RTT_ERROR("Failed to release interface")
+    }
+
     // Close the usb device
     libusb_close(this->deviceHandle);
     RTT_DEBUG("Closed basestation(", this->identifier.toString(), ")")

--- a/src/basestation/BasestationCollection.cpp
+++ b/src/basestation/BasestationCollection.cpp
@@ -486,9 +486,9 @@ void BasestationCollection::onMessageFromBasestation(const BasestationMessage& m
         const auto selectedYellowCopy = this->getSelectedBasestation(utils::TeamColor::YELLOW);
         const auto selectedBlueCopy = this->getSelectedBasestation(utils::TeamColor::BLUE);
         
-        if (selectedYellowCopy->operator==(basestationId)) {
+        if (selectedYellowCopy != nullptr && selectedYellowCopy->operator==(basestationId)) {
             this->messageFromBasestationCallback(message, utils::TeamColor::YELLOW);
-        } else if (selectedBlueCopy->operator==(basestationId)) {
+        } else if (selectedBlueCopy != nullptr && selectedBlueCopy->operator==(basestationId)) {
             this->messageFromBasestationCallback(message, utils::TeamColor::BLUE);
         }
     }

--- a/src/basestation/BasestationCollection.cpp
+++ b/src/basestation/BasestationCollection.cpp
@@ -22,9 +22,12 @@ BasestationCollection::~BasestationCollection() {
     }
 }
 
-// Updates current basestations list by comparing it with the given plugged-in basestation devices list
 void BasestationCollection::updateBasestationCollection(const std::vector<libusb_device*>& pluggedBasestationDevices) {
-    // Remove basestations that are not plugged in anymore
+    this->removeOldBasestations(pluggedBasestationDevices);
+    this->addNewBasestations(pluggedBasestationDevices);
+}
+
+void BasestationCollection::removeOldBasestations(const std::vector<libusb_device*>& pluggedBasestationDevices) {
     auto iterator = this->basestations.begin();
     while (iterator != this->basestations.end()) {
         auto basestation = *iterator;
@@ -45,7 +48,9 @@ void BasestationCollection::updateBasestationCollection(const std::vector<libusb
             ++iterator;
         }
     }
+}
 
+void BasestationCollection::addNewBasestations(const std::vector<libusb_device*>& pluggedBasestationDevices) {
     auto callbackForNewBasestations = [&](const BasestationMessage& message, uint8_t serialID) {
         this->onMessageFromBasestation(message, serialID);
     };

--- a/src/basestation/BasestationCollection.cpp
+++ b/src/basestation/BasestationCollection.cpp
@@ -79,18 +79,18 @@ void BasestationCollection::addNewBasestations(const std::vector<libusb_device*>
     }
 }
 
-bool BasestationCollection::sendMessageToBasestation(BasestationMessage& message, utils::TeamColor teamColor) {
+int BasestationCollection::sendMessageToBasestation(BasestationMessage& message, utils::TeamColor teamColor) {
     const auto& basestation = teamColor == utils::TeamColor::YELLOW ? this->getSelectedBasestation(utils::TeamColor::YELLOW) : this->getSelectedBasestation(utils::TeamColor::BLUE);
 
-    bool sentMessage = false;
+    int bytesSent = -1;
     if (basestation != nullptr) {
-        sentMessage = basestation->sendMessageToBasestation(message);
+        bytesSent = basestation->sendMessageToBasestation(message);
     }
 
     // Update our basestations usage
     this->updateWantedBasestations(teamColor);
 
-    return sentMessage;
+    return bytesSent;
 }
 
 void BasestationCollection::setIncomingMessageCallback(std::function<void(const BasestationMessage&, utils::TeamColor)> callback) {
@@ -104,7 +104,7 @@ const BasestationCollectionStatus BasestationCollection::getStatus() {
         .hasBlueBasestation = this->getSelectedBasestation(utils::TeamColor::BLUE) != nullptr,
         .amountOfBasestations = (int) basestations.size()
     };
-    
+
     return status;
 }
 

--- a/src/basestation/BasestationCollection.cpp
+++ b/src/basestation/BasestationCollection.cpp
@@ -1,10 +1,10 @@
 #include <BasestationConfiguration.h>     // REM packet
 #include <BasestationGetConfiguration.h>  // REM packet
 #include <BasestationSetConfiguration.h>  // REM packet
+#include <roboteam_utils/Print.h>
 
 #include <basestation/BasestationCollection.hpp>
 #include <cstring>
-#include <roboteam_utils/Print.h>
 
 namespace rtt::robothub::basestation {
 

--- a/src/basestation/BasestationCollection.cpp
+++ b/src/basestation/BasestationCollection.cpp
@@ -61,7 +61,7 @@ void BasestationCollection::addNewBasestations(const std::vector<libusb_device*>
     };
 
     // Add plugged in basestations that are not in the list yet
-    for (libusb_device* pluggedBasestationDevices : pluggedBasestationDevices) {
+    for (libusb_device * const pluggedBasestationDevices : pluggedBasestationDevices) {
         if (!deviceIsInBasestationList(pluggedBasestationDevices, this->basestations)) {
             // This basestation is plugged in but not in the list -> add it
             try {
@@ -97,7 +97,7 @@ void BasestationCollection::setIncomingMessageCallback(std::function<void(const 
     this->messageFromBasestationCallback = callback;
 }
 
-const BasestationCollectionStatus BasestationCollection::getStatus() {
+const BasestationCollectionStatus BasestationCollection::getStatus() const {
     const BasestationCollectionStatus status {
         .wantedBasestations = this->getWantedBasestations(),
         .hasYellowBasestation = this->getSelectedBasestation(utils::TeamColor::YELLOW) != nullptr,
@@ -108,7 +108,7 @@ const BasestationCollectionStatus BasestationCollection::getStatus() {
     return status;
 }
 
-std::vector<std::shared_ptr<Basestation>> BasestationCollection::getAllBasestations() {
+std::vector<std::shared_ptr<Basestation>> BasestationCollection::getAllBasestations() const {
     // First, lock the original basestations list
     std::scoped_lock<std::mutex> lock(this->basestationsMutex);
 
@@ -120,7 +120,7 @@ std::vector<std::shared_ptr<Basestation>> BasestationCollection::getAllBasestati
     return copyVector;
 }
 
-std::shared_ptr<Basestation> BasestationCollection::getSelectedBasestation(utils::TeamColor colorOfBasestation) {
+std::shared_ptr<Basestation> BasestationCollection::getSelectedBasestation(utils::TeamColor colorOfBasestation) const {
     std::shared_ptr<Basestation> basestation;
 
     std::scoped_lock<std::mutex> lock(this->basestationSelectionMutex);
@@ -149,7 +149,7 @@ void BasestationCollection::setSelectedBasestation(std::shared_ptr<Basestation> 
     }
 }
 
-WirelessChannel BasestationCollection::getChannelOfBasestation(const BasestationIdentifier& basestationId) {
+WirelessChannel BasestationCollection::getChannelOfBasestation(const BasestationIdentifier& basestationId) const {
     WirelessChannel channel = WirelessChannel::UNKNOWN;
 
     // Lock the map for thread safety
@@ -233,7 +233,7 @@ void BasestationCollection::updateBasestationSelection() {
     }
 }
 
-void BasestationCollection::askChannelOfBasestationsWithUnknownChannel() {
+void BasestationCollection::askChannelOfBasestationsWithUnknownChannel() const {
     // Create the channel request message
     BasestationGetConfiguration getConfigurationMessage;
     getConfigurationMessage.header = PACKET_TYPE_BASESTATION_GET_CONFIGURATION;
@@ -246,7 +246,7 @@ void BasestationCollection::askChannelOfBasestationsWithUnknownChannel() {
     std::memcpy(&message.payloadBuffer, &getConfigurationPayload.payload, message.payloadSize);
     
     // Send it to every basestation with unknown channel
-    for (auto basestation : this->getAllBasestations()) {
+    for (const auto& basestation : this->getAllBasestations()) {
         WirelessChannel channel = this->getChannelOfBasestation(basestation->getIdentifier());
         if (channel == WirelessChannel::UNKNOWN) {
             basestation->sendMessageToBasestation(message);
@@ -254,7 +254,7 @@ void BasestationCollection::askChannelOfBasestationsWithUnknownChannel() {
     }
 }
 
-std::vector<std::shared_ptr<Basestation>> BasestationCollection::getSelectableBasestations() {
+std::vector<std::shared_ptr<Basestation>> BasestationCollection::getSelectableBasestations() const {
     const auto selectedYellowCopy = this->getSelectedBasestation(utils::TeamColor::YELLOW);
     const auto selectedBlueCopy = this->getSelectedBasestation(utils::TeamColor::BLUE);
     
@@ -273,7 +273,7 @@ std::vector<std::shared_ptr<Basestation>> BasestationCollection::getSelectableBa
     return std::move(selectableBasestations);
 }
 
-bool BasestationCollection::sendChannelChangeRequest(std::shared_ptr<Basestation> basestation, WirelessChannel newChannel) {
+bool BasestationCollection::sendChannelChangeRequest(const std::shared_ptr<Basestation>& basestation, WirelessChannel newChannel) {
 
     BasestationSetConfiguration setConfigurationCommand;
     setConfigurationCommand.header = PACKET_TYPE_BASESTATION_SET_CONFIGURATION;
@@ -485,10 +485,10 @@ utils::TeamColor BasestationCollection::getTeamColorCorrespondingWirelessChannel
     }
 }
 
-bool BasestationCollection::basestationIsInDeviceList(std::shared_ptr<Basestation> basestation, const std::vector<libusb_device*>& devices) {
+bool BasestationCollection::basestationIsInDeviceList(const std::shared_ptr<Basestation>& basestation, const std::vector<libusb_device*>& devices) {
     bool basestationIsInList = false;
 
-    for (auto device : devices) {
+    for (const auto& device : devices) {
         if (*basestation == device) {
             basestationIsInList = true;
             break;
@@ -498,10 +498,10 @@ bool BasestationCollection::basestationIsInDeviceList(std::shared_ptr<Basestatio
     return basestationIsInList;
 }
 
-bool BasestationCollection::deviceIsInBasestationList(libusb_device* device, const std::vector<std::shared_ptr<Basestation>>& basestations) {
+bool BasestationCollection::deviceIsInBasestationList(libusb_device* const device, const std::vector<std::shared_ptr<Basestation>>& basestations) {
     bool deviceIsInList = false;
 
-    for (auto basestation : basestations) {
+    for (const auto& basestation : basestations) {
         if (*basestation == device) {
             deviceIsInList = true;
             break;

--- a/src/basestation/BasestationCollection.cpp
+++ b/src/basestation/BasestationCollection.cpp
@@ -8,8 +8,8 @@
 
 namespace rtt::robothub::basestation {
 
-constexpr int TIME_UNTILL_BASESTATION_IS_UNWANTED_S = 3;  // 3 seconds with no interaction
-constexpr int BASESTATION_SELECTION_UPDATE_FREQUENCY_MS = 500;
+constexpr int TIME_UNTILL_BASESTATION_IS_UNWANTED_S = 1;  // 1 second with no interaction
+constexpr int BASESTATION_SELECTION_UPDATE_FREQUENCY_MS = 420; // Why 420? No reason at all...
 
 BasestationCollection::BasestationCollection() {
     this->shouldUpdateBasestationSelection = true;
@@ -97,53 +97,15 @@ void BasestationCollection::setIncomingMessageCallback(std::function<void(const 
     this->messageFromBasestationCallback = callback;
 }
 
-void BasestationCollection::printCollection() {
-    const std::string yes = "yes    ";
-    const std::string no =  "no     ";
-    const std::string yellow =  "yellow ";
-    const std::string blue =    "blue   ";
-    const std::string unknown = "unknown";
-
-    const auto selectedYellowCopy = this->getSelectedBasestation(utils::TeamColor::YELLOW);
-
-    std::string yellowFilled = selectedYellowCopy != nullptr ? yes : no;
-    std::string yellowChannel = unknown;
-    if (selectedYellowCopy != nullptr) {
-        WirelessChannel channel = this->getChannelOfBasestation(selectedYellowCopy->getIdentifier());
-        if (channel == WirelessChannel::BLUE_CHANNEL) {
-            yellowChannel = blue;
-        } else if (channel == WirelessChannel::YELLOW_CHANNEL) {
-            yellowChannel = yellow;
-        }
-    }
-
-    const auto selectedBlueCopy = this->getSelectedBasestation(utils::TeamColor::BLUE);
-
-    std::string blueFilled = selectedBlueCopy != nullptr ? yes : no;
-    std::string blueChannel = unknown;
-    if (selectedBlueCopy != nullptr) {
-        WirelessChannel channel = this->getChannelOfBasestation(selectedBlueCopy->getIdentifier());
-        if (channel == WirelessChannel::BLUE_CHANNEL) {
-            blueChannel = blue;
-        } else if (channel == WirelessChannel::YELLOW_CHANNEL) {
-            blueChannel = yellow;
-        }
-    }
-
-    auto selectableBasestations = this->getSelectableBasestations();
-    int remaining = selectableBasestations.size();
-
-    std::cout << "==== Yellow slot ====== Blue slot =====" << std::endl
-              << "| filled:  " << yellowFilled << " | filled:  " << blueFilled << " |" << std::endl
-              << "| channel: " << yellowChannel << " | channel: " << blueChannel << " |" << std::endl
-              << "|----- Remaining: " << remaining << ", Waiting: ? ------|" << std::endl;
-
-    int i = 0;
-    for (const auto& basestation : this->getSelectableBasestations()) {
-        auto channel = this->getChannelOfBasestation(basestation->getIdentifier());
-        std::cout << "|- " << i << ": " << BasestationCollection::wirelessChannelToString(channel) << std::endl;
-    }
-    std::cout << std::endl;
+const BasestationCollectionStatus BasestationCollection::getStatus() {
+    const BasestationCollectionStatus status {
+        .wantedBasestations = this->getWantedBasestations(),
+        .hasYellowBasestation = this->getSelectedBasestation(utils::TeamColor::YELLOW) != nullptr,
+        .hasBlueBasestation = this->getSelectedBasestation(utils::TeamColor::BLUE) != nullptr,
+        .amountOfBasestations = (int) basestations.size()
+    };
+    
+    return status;
 }
 
 std::vector<std::shared_ptr<Basestation>> BasestationCollection::getAllBasestations() {

--- a/src/basestation/BasestationCollection.cpp
+++ b/src/basestation/BasestationCollection.cpp
@@ -4,7 +4,7 @@
 
 #include <basestation/BasestationCollection.hpp>
 #include <cstring>
-#include <iostream>
+#include <roboteam_utils/Print.h>
 
 namespace rtt::robothub::basestation {
 
@@ -70,8 +70,8 @@ void BasestationCollection::addNewBasestations(const std::vector<libusb_device*>
                 std::scoped_lock<std::mutex> lock(this->basestationsMutex);
                 this->basestations.push_back(newBasestation);
             } catch (FailedToOpenDeviceException e) {
-                std::cout << "Error: " << e.what() << std::endl;
-                std::cout << "Did you edit your PC's user permissions?" << std::endl;
+                RTT_ERROR(e.what())
+                RTT_INFO("Did you edit your PC's user permissions?")
             }
         }
     }
@@ -215,7 +215,7 @@ void BasestationCollection::updateBasestationSelection() {
     while (this->shouldUpdateBasestationSelection) {
         int wrongBasestations = this->unselectIncorrectlySelectedBasestations();
         if (wrongBasestations > 0) {
-            std::cout << "Warning: Incorrect basestations were selected!" << std::endl;
+            RTT_WARNING("Selected basestation(s) had incorrect channel(s)")
         }
 
         this->askChannelOfBasestationsWithUnknownChannel();

--- a/src/basestation/BasestationManager.cpp
+++ b/src/basestation/BasestationManager.cpp
@@ -102,10 +102,10 @@ const BasestationManagerStatus BasestationManager::getStatus() const {
     return status;
 }
 
-std::vector<libusb_device*> BasestationManager::filterBasestationDevices(libusb_device** devices, int device_count) {
+std::vector<libusb_device*> BasestationManager::filterBasestationDevices(libusb_device*const*const devices, int device_count) {
     std::vector<libusb_device*> basestations;
     for (int i = 0; i < device_count; ++i) {
-        libusb_device* device = devices[i];
+        libusb_device* const device = devices[i];
 
         if (Basestation::isDeviceABasestation(device)) {
             basestations.push_back(device);

--- a/src/basestation/BasestationManager.cpp
+++ b/src/basestation/BasestationManager.cpp
@@ -33,7 +33,7 @@ BasestationManager::~BasestationManager() {
     libusb_exit(this->usbContext);
 }
 
-bool BasestationManager::sendRobotCommand(const RobotCommand& command, utils::TeamColor color) const {
+int BasestationManager::sendRobotCommand(const RobotCommand& command, utils::TeamColor color) const {
     RobotCommand copy = command;  // TODO: Make REM encodeRobotCommand use const so copy is unecessary
 
     RobotCommandPayload payload;
@@ -43,10 +43,11 @@ bool BasestationManager::sendRobotCommand(const RobotCommand& command, utils::Te
     message.payloadSize = PACKET_SIZE_ROBOT_COMMAND;
     std::memcpy(&message.payloadBuffer, payload.payload, message.payloadSize);
 
-    return this->basestationCollection->sendMessageToBasestation(message, color);
+    int bytesSent = this->basestationCollection->sendMessageToBasestation(message, color);
+    return bytesSent;
 }
 
-bool BasestationManager::sendRobotBuzzerCommand(const RobotBuzzer& command, utils::TeamColor color) const {
+int BasestationManager::sendRobotBuzzerCommand(const RobotBuzzer& command, utils::TeamColor color) const {
     RobotBuzzer copy = command;
 
     RobotBuzzerPayload payload;
@@ -56,10 +57,11 @@ bool BasestationManager::sendRobotBuzzerCommand(const RobotBuzzer& command, util
     message.payloadSize = PACKET_SIZE_ROBOT_BUZZER;
     std::memcpy(message.payloadBuffer, payload.payload, message.payloadSize);
 
-    return this->basestationCollection->sendMessageToBasestation(message, color);
+    int bytesSent = this->basestationCollection->sendMessageToBasestation(message, color);
+    return bytesSent;
 }
 
-bool BasestationManager::sendBasestationStatisticsRequest(utils::TeamColor color) const {
+int BasestationManager::sendBasestationStatisticsRequest(utils::TeamColor color) const {
     BasestationGetStatistics command;
 
     BasestationGetStatisticsPayload payload;
@@ -69,7 +71,8 @@ bool BasestationManager::sendBasestationStatisticsRequest(utils::TeamColor color
     message.payloadSize = PACKET_SIZE_BASESTATION_GET_STATISTICS;
     std::memcpy(message.payloadBuffer, &payload.payload, message.payloadSize);
 
-    return this->basestationCollection->sendMessageToBasestation(message, color);
+    int bytesSent = this->basestationCollection->sendMessageToBasestation(message, color);
+    return bytesSent;
 }
 
 void BasestationManager::setFeedbackCallback(const std::function<void(const RobotFeedback&, utils::TeamColor)>& callback) { this->feedbackCallbackFunction = callback; }

--- a/src/basestation/BasestationManager.cpp
+++ b/src/basestation/BasestationManager.cpp
@@ -91,7 +91,13 @@ void BasestationManager::listenForBasestationPlugs() {
     }
 }
 
-void BasestationManager::printStatus() const { this->basestationCollection->printCollection(); }
+const BasestationManagerStatus BasestationManager::getStatus() const {
+    const BasestationManagerStatus status = {
+        .basestationCollection = this->basestationCollection->getStatus()
+    };
+
+    return status;
+}
 
 std::vector<libusb_device*> BasestationManager::filterBasestationDevices(libusb_device** devices, int device_count) {
     std::vector<libusb_device*> basestations;

--- a/src/basestation/BasestationManager.cpp
+++ b/src/basestation/BasestationManager.cpp
@@ -95,14 +95,12 @@ void BasestationManager::listenForBasestationPlugs() {
 }
 
 const BasestationManagerStatus BasestationManager::getStatus() const {
-    const BasestationManagerStatus status = {
-        .basestationCollection = this->basestationCollection->getStatus()
-    };
+    const BasestationManagerStatus status = {.basestationCollection = this->basestationCollection->getStatus()};
 
     return status;
 }
 
-std::vector<libusb_device*> BasestationManager::filterBasestationDevices(libusb_device*const*const devices, int device_count) {
+std::vector<libusb_device*> BasestationManager::filterBasestationDevices(libusb_device* const* const devices, int device_count) {
     std::vector<libusb_device*> basestations;
     for (int i = 0; i < device_count; ++i) {
         libusb_device* const device = devices[i];

--- a/src/basestation/BasestationManager.cpp
+++ b/src/basestation/BasestationManager.cpp
@@ -84,7 +84,7 @@ void BasestationManager::listenForBasestationPlugs() {
 
         std::vector<libusb_device*> basestationDevices = filterBasestationDevices(device_list, device_count);
 
-        this->basestationCollection->updateBasestationList(basestationDevices);
+        this->basestationCollection->updateBasestationCollection(basestationDevices);
 
         // Free the list of devices
         libusb_free_device_list(device_list, true);

--- a/src/simulation/SimulatorManager.cpp
+++ b/src/simulation/SimulatorManager.cpp
@@ -1,5 +1,7 @@
 #include <simulation/SimulatorManager.hpp>
 
+#include <roboteam_utils/Print.h>
+
 namespace rtt::robothub::simulation {
 
 constexpr int LISTEN_THREAD_COOLDOWN_MS = 10;  // Small cooldown in thread between checking for new messsages
@@ -17,13 +19,14 @@ SimulatorManager::SimulatorManager(SimulatorNetworkConfiguration config) {
 
     this->shouldStopListeningToFeedback = false;
 
-    std::cout << "SimulationManager bound on: " << std::endl
-              << " - Blue Control Port: " << config.blueControlPort << std::endl
-              << " - Blue Feedback Port: " << config.blueFeedbackPort << std::endl
-              << " - Yellow Control Port: " << config.yellowControlPort << std::endl
-              << " - Yellow Feedback Port: " << config.yellowFeedbackPort << std::endl
-              << " - Simulation Control Port: " << config.configurationPort << std::endl
-              << " - Simulation Feedback Port: " << config.configurationFeedbackPort << std::endl;
+    RTT_INFO("\n"
+             "SimulationManager bound on:", "\n",
+             " - Blue Control Port: ", config.blueControlPort, "\n",
+             " - Blue Feedback Port: ", config.blueFeedbackPort, "\n",
+             " - Yellow Control Port: ", config.yellowControlPort, "\n",
+             " - Yellow Feedback Port: ", config.yellowFeedbackPort, "\n",
+             " - Simulation Control Port: ", config.configurationPort, "\n",
+             " - Simulation Feedback Port: ", config.configurationFeedbackPort)
 
     // Spawn listening threads that handle incoming feedback
     this->blueFeedbackListenThread = std::thread([this] { listenForRobotControlFeedback(utils::TeamColor::BLUE); });

--- a/src/simulation/SimulatorManager.cpp
+++ b/src/simulation/SimulatorManager.cpp
@@ -1,6 +1,6 @@
-#include <simulation/SimulatorManager.hpp>
-
 #include <roboteam_utils/Print.h>
+
+#include <simulation/SimulatorManager.hpp>
 
 namespace rtt::robothub::simulation {
 
@@ -19,14 +19,12 @@ SimulatorManager::SimulatorManager(SimulatorNetworkConfiguration config) {
 
     this->shouldStopListeningToFeedback = false;
 
-    RTT_INFO("\n"
-             "SimulationManager bound on:", "\n",
-             " - Blue Control Port: ", config.blueControlPort, "\n",
-             " - Blue Feedback Port: ", config.blueFeedbackPort, "\n",
-             " - Yellow Control Port: ", config.yellowControlPort, "\n",
-             " - Yellow Feedback Port: ", config.yellowFeedbackPort, "\n",
-             " - Simulation Control Port: ", config.configurationPort, "\n",
-             " - Simulation Feedback Port: ", config.configurationFeedbackPort)
+    RTT_INFO(
+        "\n"
+        "SimulationManager bound on:",
+        "\n", " - Blue Control Port: ", config.blueControlPort, "\n", " - Blue Feedback Port: ", config.blueFeedbackPort, "\n",
+        " - Yellow Control Port: ", config.yellowControlPort, "\n", " - Yellow Feedback Port: ", config.yellowFeedbackPort, "\n",
+        " - Simulation Control Port: ", config.configurationPort, "\n", " - Simulation Feedback Port: ", config.configurationFeedbackPort)
 
     // Spawn listening threads that handle incoming feedback
     this->blueFeedbackListenThread = std::thread([this] { listenForRobotControlFeedback(utils::TeamColor::BLUE); });

--- a/test/SendRobotCommands.cpp
+++ b/test/SendRobotCommands.cpp
@@ -1,0 +1,371 @@
+#include <RobotCommandsNetworker.hpp>
+#include <RobotFeedbackNetworker.hpp>
+#include <SettingsNetworker.hpp>
+
+#include <iostream>
+#include <memory>
+#include <chrono>
+#include <thread>
+#include <string>
+
+using namespace rtt::net;
+
+constexpr int MAX_AMOUNT_OF_ROBOTS = 16;
+constexpr float ROTATE_SPEED = 2.0f;
+
+enum Command {
+    INVALID,
+    HELP,
+
+    MODE_TO_BASESTATION,
+    MODE_TO_SIMULATOR,
+
+    SEND_ROTATE_LEFT_COMMANDS,
+    SEND_ROTATE_RIGHT_COMMANDS,
+    SEND_HALT_COMMANDS,
+
+    DO_NOT_SEND,
+    SEND_TO_YELLOW,
+    SEND_TO_BLUE,
+    SEND_TO_BOTH,
+
+    ROBOT_ID,
+    ALL_ROBOTS,
+
+    STOP
+};
+
+enum Mode {
+    BASESTATION, SIMULATOR
+};
+enum RobotCommand {
+    HALT, LEFT, RIGHT
+};
+enum Team {
+    NEITHER, YELLOW, BLUE, BOTH
+};
+
+Mode mode = Mode::BASESTATION;
+RobotCommand robotCommand = RobotCommand::HALT;
+Team team = Team::NEITHER;
+int robotId = 0;
+bool sendToAllRobots = false;
+
+bool shouldRunCommands = true;
+bool shouldAskCommands = true;
+
+void printCommandOptions() {
+    std::cout << "The commands you can enter are:" << std::endl
+              << "- basestation : For changing RobotHub to basestation mode" << std::endl
+              << "- simulator   : For changing RobotHub to simulation mode" << std::endl
+              << "- left        : For sending robot commands to rotate to the left" << std::endl
+              << "- right       : For sending robot commands to rotate to the right" << std::endl
+              << "- halt        : For sending empty commands to the robots" << std::endl
+              << "- neither     : For not sending commands at all" << std::endl
+              << "- yellow      : For sending commands only to yellow team" << std::endl
+              << "- blue        : For sending commands only to blue team" << std::endl
+              << "- both        : For sending commands to both teams" << std::endl
+              << "- 0..15       : For sending to an individual robot" << std::endl
+              << "- all         : For sending to all robots" << std::endl
+              << "- help        : For displaying this message" << std::endl;
+}
+
+int stringToRobotId(std::string s) {
+    if (s == "0") {
+        return 0;
+    } else if (s == "1") {
+        return 1;
+    } else if (s == "2") {
+        return 2;
+    } else if (s == "3") {
+        return 3;
+    } else if (s == "4") {
+        return 4;
+    } else if (s == "5") {
+        return 5;
+    } else if (s == "6") {
+        return 6;
+    } else if (s == "7") {
+        return 7;
+    } else if (s == "8") {
+        return 8;
+    } else if (s == "9") {
+        return 9;
+    } else if (s == "10") {
+        return 10;
+    } else if (s == "11") {
+        return 11;
+    } else if (s == "12") {
+        return 12;
+    } else if (s == "13") {
+        return 13;
+    } else if (s == "14") {
+        return 14;
+    } else if (s == "15") {
+        return 15;
+    } else {
+        return -1;
+    }
+}
+
+Command askCommand() {
+    Command command = Command::INVALID;
+
+    while (command == Command::INVALID) {
+        std::cout << "Enter command: ";
+        std::string enteredCommand;
+        std::getline(std::cin, enteredCommand);
+        for (auto& c : enteredCommand) c = toupper(c); // Make command upper case
+
+        if (enteredCommand == "HELP") {
+            command = Command::HELP;
+        } else if (enteredCommand == "BASESTATION") {       // Basestation
+            command = Command::MODE_TO_BASESTATION;
+        } else if (enteredCommand == "SIMULATOR") {         // Simulator
+            command = Command::MODE_TO_SIMULATOR;
+        } else if (enteredCommand == "LEFT") {              // Left
+            command = Command::SEND_ROTATE_LEFT_COMMANDS;
+        } else if (enteredCommand == "RIGHT") {             // Right
+            command = Command::SEND_ROTATE_RIGHT_COMMANDS;
+        } else if (enteredCommand == "HALT") {              // Halt
+            command = Command::SEND_HALT_COMMANDS;
+        } else if (enteredCommand == "NEITHER") {           // Neither
+            command = Command::DO_NOT_SEND;
+        } else if (enteredCommand == "YELLOW") {            // Yellow
+            command = Command::SEND_TO_YELLOW;
+        } else if (enteredCommand == "BLUE") {              // Blue
+            command = Command::SEND_TO_BLUE;
+        } else if (enteredCommand == "BOTH") {              // Both
+            command = Command::SEND_TO_BOTH;
+        } else if (enteredCommand == "HELP") {              // Help
+            command = Command::HELP;
+        } else if (stringToRobotId(enteredCommand) >= 0) {
+            robotId = stringToRobotId(enteredCommand);
+            command = Command::ROBOT_ID;
+        } else if (enteredCommand == "ALL") {
+            command = Command::ALL_ROBOTS;
+        } else if (enteredCommand == "STOP") {
+            command = Command::STOP;
+        } else {
+            std::cout << "Invalid command: '" << enteredCommand << "'. Enter 'help' for more information." << std::endl << std::endl;
+        }
+    }
+    return command;
+}
+
+void handleCommand(Command command) {
+    switch (command) {
+        case Command::HELP: {
+            printCommandOptions();
+            break;
+        } case Command::MODE_TO_BASESTATION: {
+            mode = Mode::BASESTATION;
+            break;
+        } case Command::MODE_TO_SIMULATOR: {
+            mode = Mode::SIMULATOR;
+            break;
+        } case Command::SEND_ROTATE_LEFT_COMMANDS: {
+            robotCommand = RobotCommand::LEFT;
+            break;
+        } case Command::SEND_ROTATE_RIGHT_COMMANDS: {
+            robotCommand = RobotCommand::RIGHT;
+            break;
+        } case Command::SEND_HALT_COMMANDS: {
+            robotCommand = RobotCommand::HALT;
+            break;
+        } case Command::DO_NOT_SEND: {
+            team = Team::NEITHER;
+            break;
+        } case Command::SEND_TO_YELLOW: {
+            team = Team::YELLOW;
+            break;
+        } case Command::SEND_TO_BLUE: {
+            team = Team::BLUE;
+            break;
+        } case Command::SEND_TO_BOTH: {
+            team = Team::BOTH;
+            break;
+        } case Command::ROBOT_ID: {
+            sendToAllRobots = false;
+            break;
+        } case Command::ALL_ROBOTS: {
+            sendToAllRobots = true;
+            break;
+        } case Command::STOP: {
+            shouldAskCommands = false;
+            break;
+        } default: {
+            std::cout << "Unknown command" << std::endl;
+            break;
+        }
+    }
+}
+
+proto::Setting getSettingsCommand() {
+    proto::Setting settings;
+    settings.set_serialmode(mode == Mode::BASESTATION);
+    return settings;
+}
+
+void addHaltCommandForRobot(int id, proto::AICommand& command) {
+    auto robotCommand = command.add_commands();
+    robotCommand->set_id(id);
+    robotCommand->mutable_vel()->set_x(0);
+    robotCommand->mutable_vel()->set_y(0);
+    robotCommand->set_w(0);
+    robotCommand->set_use_angle(false);
+    robotCommand->set_dribbler(false);
+    robotCommand->set_kicker(false);
+    robotCommand->set_chipper(false);
+    robotCommand->set_chip_kick_forced(false);
+    robotCommand->set_chip_kick_vel(false);
+}
+
+void addRotateLeftCommandForRobot(int id, proto::AICommand& command) {
+    auto robotCommand = command.add_commands();
+    robotCommand->set_id(id);
+    robotCommand->mutable_vel()->set_x(0);
+    robotCommand->mutable_vel()->set_y(0);
+    robotCommand->set_w(ROTATE_SPEED);
+    robotCommand->set_use_angle(false);
+    robotCommand->set_dribbler(false);
+    robotCommand->set_kicker(false);
+    robotCommand->set_chipper(false);
+    robotCommand->set_chip_kick_forced(false);
+    robotCommand->set_chip_kick_vel(false);
+}
+
+void addRotateRightCommandForRobot(int id, proto::AICommand& command) {
+    auto robotCommand = command.add_commands();
+    robotCommand->set_id(id);
+    robotCommand->mutable_vel()->set_x(0);
+    robotCommand->mutable_vel()->set_y(0);
+    robotCommand->set_w(-ROTATE_SPEED);
+    robotCommand->set_use_angle(false);
+    robotCommand->set_dribbler(false);
+    robotCommand->set_kicker(false);
+    robotCommand->set_chipper(false);
+    robotCommand->set_chip_kick_forced(false);
+    robotCommand->set_chip_kick_vel(false);
+}
+
+proto::AICommand getCommandToSend() {
+    proto::AICommand command;
+
+    if (robotCommand == RobotCommand::HALT) {
+        if (sendToAllRobots) {
+            for (int id = 0; id < MAX_AMOUNT_OF_ROBOTS; ++id) {
+                addHaltCommandForRobot(id, command);
+            }
+        } else {
+            addHaltCommandForRobot(robotId, command);
+        }
+    } else if (robotCommand == RobotCommand::LEFT) {
+        if (sendToAllRobots) {
+            for (int id = 0; id < MAX_AMOUNT_OF_ROBOTS; ++id) {
+                addRotateLeftCommandForRobot(id, command);
+            }
+        } else {
+            addRotateLeftCommandForRobot(robotId, command);
+        }
+    } else if (robotCommand == RobotCommand::RIGHT) {
+        if (sendToAllRobots) {
+            for (int id = 0; id < MAX_AMOUNT_OF_ROBOTS; ++id) {
+                addRotateRightCommandForRobot(id, command);
+            }
+        } else {
+            addRotateRightCommandForRobot(robotId, command);
+        }
+    }
+    return command;
+}
+
+void runCommands() {
+    std::unique_ptr<RobotCommandsYellowPublisher> yellowCommandsPub = std::make_unique<RobotCommandsYellowPublisher>();
+    std::unique_ptr<RobotCommandsBluePublisher> blueCommandsPub = std::make_unique<RobotCommandsBluePublisher>();
+    std::unique_ptr<SettingsPublisher> settingsPub = std::make_unique<SettingsPublisher>();
+
+    while (shouldRunCommands) {
+        settingsPub->publish(getSettingsCommand());
+
+        proto::AICommand commandToSend = getCommandToSend();
+
+        if (team == Team::YELLOW) {
+            yellowCommandsPub->publish(commandToSend);
+        } else if (team == Team::BLUE) {
+            blueCommandsPub->publish(commandToSend);
+        } else if (team == Team::BOTH) {
+            yellowCommandsPub->publish(commandToSend);
+            blueCommandsPub->publish(commandToSend);
+        }
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    }
+}
+
+std::string getCurrentTargetTeam() {
+    switch (team) {
+        case Team::NEITHER:
+            return "no team";
+        case Team::YELLOW:
+            return "team yellow";
+        case Team::BLUE:
+            return "team blue";
+        case Team::BOTH:
+            return "both teams";
+        default:
+            return "unknown";
+    }
+}
+
+std::string getCurrentCommand() {
+    switch (robotCommand) {
+        case RobotCommand::HALT:
+            return "halt";
+        case RobotCommand::LEFT:
+            return "rotate left";
+        case RobotCommand::RIGHT:
+            return "rotate right";
+        default:
+            return "unknown";
+    }
+}
+
+std::string getCurrentMode() {
+    switch (mode) {
+        case Mode::BASESTATION:
+            return "basestation";
+        case Mode::SIMULATOR:
+            return "simulator";
+        default:
+            return "unknown";
+    }
+}
+
+std::string getRobotTargets() {
+    if (sendToAllRobots) {
+        return "all robots";
+    } else {
+        return "robot " + std::to_string(robotId);
+    }
+}
+
+void printCommandStatus() {
+    std::cout << "Sending " << getCurrentCommand() << " to " << getRobotTargets() << " of " << getCurrentTargetTeam() << " via the " << getCurrentMode() << std::endl;
+}
+
+int main() {
+    std::thread commandRunner(runCommands);
+
+    while (shouldAskCommands) {
+        printCommandStatus();
+        handleCommand(askCommand());
+        std::cout << std::endl;
+    }
+
+    shouldRunCommands = false;
+    if (commandRunner.joinable()) {
+        commandRunner.join();
+    }
+    return 0;
+}

--- a/test/sendFormationToSimulator.cpp
+++ b/test/sendFormationToSimulator.cpp
@@ -2,17 +2,15 @@
 // Created by tijmen on 13-01-22.
 //
 
-#include <simulation/SimulatorManager.hpp>
 #include <utilities.h>
 
-int main () {
+#include <simulation/SimulatorManager.hpp>
 
+int main() {
     using namespace rtt::robothub::simulation;
 
     // GrSim does not allow a bidirectional udp connection, so it uses different ports for the feedback
-    SimulatorNetworkConfiguration config = { .blueFeedbackPort = 30011,
-                                             .yellowFeedbackPort = 30012,
-                                             .configurationFeedbackPort = 30013 };
+    SimulatorNetworkConfiguration config = {.blueFeedbackPort = 30011, .yellowFeedbackPort = 30012, .configurationFeedbackPort = 30013};
 
     std::unique_ptr<SimulatorManager> manager;
 
@@ -37,12 +35,10 @@ int main () {
 
     configurationCommand.setBallLocation(0, 0, 0, 0, 0, 0, false, false, false);
 
-    for(int i = 4; i < 11; i++) {
+    for (int i = 4; i < 11; i++) {
         configurationCommand.addRobotLocation(i, rtt::robothub::utils::TeamColor::YELLOW, 0, 0, 0, 0, 0, 0, false, false);
         configurationCommand.addRobotLocation(i, rtt::robothub::utils::TeamColor::BLUE, 0, 0, 0, 0, 0, 0, false, false);
     }
 
-
     manager->sendConfigurationCommand(configurationCommand);
-
 }


### PR DESCRIPTION
This PR finalizes all implementations I originally wanted to make. This includes:
- Plug n play basestations: No need to figure out whether a basestation is blue or yellow. From now on, RobotHub can fully control the basestations' frequency.
- Thread safety: Because the classes function like black boxes, they each work on their own thread. This could theoretically cause thread unsafe behaviour, which is fixed now.
- Roboteam Utils: Now instead of simply using the std::cout library for printing messages to the console, RobotHub uses the shared Print class from the utils repository.
- More statistics: Previously, we only saw what entered RobotHub. We kept track what AI commands we received and what robot feedback we received. But there are other major point of failures too, like sending messages to the basestation. Therefore, we now also keep track of how many messages leave robothub and how many of them are dropped.
- Better TUI: Because of the increase in the amount of statistics we keep track of, the console became cluttered with information. This PR puts all that information into a single nicely formatted and boxed print statement