### PR TITLE
Use the new REM names to prevent name clashes

### DIFF
--- a/include/RobotHub.h
+++ b/include/RobotHub.h
@@ -56,7 +56,7 @@ class RobotHub {
     void onSimulationConfiguration(const proto::SimulationConfiguration &configuration);
 
     void handleRobotFeedbackFromSimulator(const simulation::RobotControlFeedback &feedback);
-    void handleRobotFeedbackFromBasestation(const RobotFeedback &feedback, utils::TeamColor team);
+    void handleRobotFeedbackFromBasestation(const REM_RobotFeedback &feedback, utils::TeamColor team);
     bool sendRobotFeedback(const proto::RobotData &feedback);
 };
 

--- a/include/basestation/BasestationManager.hpp
+++ b/include/basestation/BasestationManager.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <RobotBuzzer.h>    // REM command
-#include <RobotCommand.h>   // REM command
-#include <RobotFeedback.h>  // REM command
+#include <REM_RobotBuzzer.h>
+#include <REM_RobotCommand.h>
+#include <REM_RobotFeedback.h>
 #include <libusb-1.0/libusb.h>
 #include <utilities.h>
 
@@ -18,11 +18,11 @@ class BasestationManager {
     BasestationManager();
     ~BasestationManager();
 
-    bool sendRobotCommand(const RobotCommand &command, utils::TeamColor color) const;
-    bool sendRobotBuzzerCommand(const RobotBuzzer &command, utils::TeamColor color) const;
+    bool sendRobotCommand(const REM_RobotCommand &command, utils::TeamColor color) const;
+    bool sendRobotBuzzerCommand(const REM_RobotBuzzer &command, utils::TeamColor color) const;
     bool sendBasestationStatisticsRequest(utils::TeamColor color) const;
 
-    void setFeedbackCallback(const std::function<void(const RobotFeedback &, utils::TeamColor color)> &callback);
+    void setFeedbackCallback(const std::function<void(const REM_RobotFeedback &, utils::TeamColor color)> &callback);
 
     void printStatus() const;
 
@@ -37,8 +37,8 @@ class BasestationManager {
 
     void handleIncomingMessage(const BasestationMessage &message, utils::TeamColor basestationColor) const;
 
-    std::function<void(const RobotFeedback &, utils::TeamColor)> feedbackCallbackFunction;
-    void callFeedbackCallback(const RobotFeedback &feedback, utils::TeamColor color) const;
+    std::function<void(const REM_RobotFeedback &, utils::TeamColor)> feedbackCallbackFunction;
+    void callFeedbackCallback(const REM_RobotFeedback &feedback, utils::TeamColor color) const;
 
     static std::vector<libusb_device *> filterBasestationDevices(libusb_device **devices, int device_count);
 };

--- a/src/RobotHub.cpp
+++ b/src/RobotHub.cpp
@@ -1,4 +1,4 @@
-#include <RobotCommand.h>
+#include <REM_RobotCommand.h>
 #include <RobotHub.h>
 
 #include <cmath>
@@ -31,7 +31,7 @@ RobotHub::RobotHub() {
     this->simulatorManager->setRobotControlFeedbackCallback([&](const simulation::RobotControlFeedback &feedback) { this->handleRobotFeedbackFromSimulator(feedback); });
 
     this->basestationManager = std::make_unique<basestation::BasestationManager>();
-    this->basestationManager->setFeedbackCallback([&](const RobotFeedback &feedback, utils::TeamColor color) { this->handleRobotFeedbackFromBasestation(feedback, color); });
+    this->basestationManager->setFeedbackCallback([&](const REM_RobotFeedback &feedback, utils::TeamColor color) { this->handleRobotFeedbackFromBasestation(feedback, color); });
 }
 
 bool RobotHub::subscribe() {
@@ -86,8 +86,8 @@ void RobotHub::sendCommandsToBasestation(const proto::AICommand &commands, utils
         float theta = atan2f(protoCommand.vel().y(), protoCommand.vel().x());
         auto bot = getWorldBot(protoCommand.id(), color, commands.extrapolatedworld());
 
-        RobotCommand command;
-        command.header = PACKET_TYPE_ROBOT_COMMAND;
+        REM_RobotCommand command;
+        command.header = PACKET_TYPE_REM_ROBOT_COMMAND;
         command.remVersion = LOCAL_REM_VERSION;
         command.id = protoCommand.id();
 
@@ -280,7 +280,7 @@ void RobotHub::handleRobotFeedbackFromSimulator(const simulation::RobotControlFe
     this->sendRobotFeedback(feedbackToBePublished);
 }
 
-void RobotHub::handleRobotFeedbackFromBasestation(const RobotFeedback &feedback, utils::TeamColor basestationColor) {
+void RobotHub::handleRobotFeedbackFromBasestation(const REM_RobotFeedback &feedback, utils::TeamColor basestationColor) {
     proto::RobotData feedbackToBePublished;
     feedbackToBePublished.set_isyellow(basestationColor == utils::TeamColor::YELLOW);
 

--- a/src/basestation/Basestation.cpp
+++ b/src/basestation/Basestation.cpp
@@ -1,6 +1,6 @@
-#include <BasestationConfiguration.h>     // REM packet
-#include <BasestationGetConfiguration.h>  // REM packet
-#include <RobotCommand.h>                 //REM packet
+#include <REM_BasestationConfiguration.h>
+#include <REM_BasestationGetConfiguration.h>
+#include <REM_RobotCommand.h>
 #include <basestation/LibusbUtilities.h>
 
 #include <basestation/Basestation.hpp>
@@ -148,12 +148,12 @@ void Basestation::listenForIncomingMessages() {
 // Assumes a payload size bigger than 0
 void Basestation::handleIncomingMessage(const BasestationMessage& message) {
     // If a basestation configuration is received, update channel of this basestation class
-    if (message.payloadBuffer[0] == PACKET_TYPE_BASESTATION_CONFIGURATION) {
-        BasestationConfigurationPayload configurationPayload;
-        std::memcpy(&configurationPayload.payload, message.payloadBuffer, PACKET_SIZE_BASESTATION_CONFIGURATION);
+    if (message.payloadBuffer[0] == PACKET_TYPE_REM_BASESTATION_CONFIGURATION) {
+        REM_BasestationConfigurationPayload configurationPayload;
+        std::memcpy(&configurationPayload.payload, message.payloadBuffer, PACKET_SIZE_REM_BASESTATION_CONFIGURATION);
 
-        BasestationConfiguration basestationConfiguration;
-        decodeBasestationConfiguration(&basestationConfiguration, &configurationPayload);
+        REM_BasestationConfiguration basestationConfiguration;
+        decodeREM_BasestationConfiguration(&basestationConfiguration, &configurationPayload);
 
         WirelessChannel usedChannel = Basestation::remChannelToWirelessChannel(basestationConfiguration.channel);
         this->channel = usedChannel;
@@ -166,14 +166,14 @@ void Basestation::handleIncomingMessage(const BasestationMessage& message) {
 }
 
 bool Basestation::requestChannelOfBasestation() {
-    BasestationGetConfiguration getConfigurationCommand;
-    getConfigurationCommand.header = PACKET_TYPE_BASESTATION_GET_CONFIGURATION;
+    REM_BasestationGetConfiguration getConfigurationCommand;
+    getConfigurationCommand.header = PACKET_TYPE_REM_BASESTATION_GET_CONFIGURATION;
 
-    BasestationGetConfigurationPayload getConfigurationPayload;
-    encodeBasestationGetConfiguration(&getConfigurationPayload, &getConfigurationCommand);
+    REM_BasestationGetConfigurationPayload getConfigurationPayload;
+    encodeREM_BasestationGetConfiguration(&getConfigurationPayload, &getConfigurationCommand);
 
     BasestationMessage message;
-    message.payloadSize = PACKET_SIZE_BASESTATION_GET_CONFIGURATION;
+    message.payloadSize = PACKET_SIZE_REM_BASESTATION_GET_CONFIGURATION;
     std::memcpy(message.payloadBuffer, getConfigurationPayload.payload, message.payloadSize);
 
     bool sentMessage = this->writeBasestationMessage(message);

--- a/src/basestation/BasestationCollection.cpp
+++ b/src/basestation/BasestationCollection.cpp
@@ -1,6 +1,3 @@
-#include <BasestationConfiguration.h>     // REM packet
-#include <BasestationSetConfiguration.h>  // REM packet
-
 #include <basestation/BasestationCollection.hpp>
 #include <iostream>
 

--- a/src/basestation/BasestationManager.cpp
+++ b/src/basestation/BasestationManager.cpp
@@ -1,4 +1,4 @@
-#include <BasestationGetStatistics.h>  // REM command
+#include <REM_BasestationGetStatistics.h>
 
 #include <basestation/BasestationManager.hpp>
 #include <cstring>
@@ -33,46 +33,46 @@ BasestationManager::~BasestationManager() {
     libusb_exit(this->usbContext);
 }
 
-bool BasestationManager::sendRobotCommand(const RobotCommand& command, utils::TeamColor color) const {
-    RobotCommand copy = command;  // TODO: Make REM encodeRobotCommand use const so copy is unecessary
+bool BasestationManager::sendRobotCommand(const REM_RobotCommand& command, utils::TeamColor color) const {
+    REM_RobotCommand copy = command;  // TODO: Make REM encodeRobotCommand use const so copy is unecessary
 
-    RobotCommandPayload payload;
-    encodeRobotCommand(&payload, &copy);
+    REM_RobotCommandPayload payload;
+    encodeREM_RobotCommand(&payload, &copy);
 
     BasestationMessage message;
-    message.payloadSize = PACKET_SIZE_ROBOT_COMMAND;
+    message.payloadSize = PACKET_SIZE_REM_ROBOT_COMMAND;
     std::memcpy(&message.payloadBuffer, payload.payload, message.payloadSize);
 
     return this->basestationCollection->sendMessageToBasestation(message, color);
 }
 
-bool BasestationManager::sendRobotBuzzerCommand(const RobotBuzzer& command, utils::TeamColor color) const {
-    RobotBuzzer copy = command;
+bool BasestationManager::sendRobotBuzzerCommand(const REM_RobotBuzzer& command, utils::TeamColor color) const {
+    REM_RobotBuzzer copy = command;
 
-    RobotBuzzerPayload payload;
-    encodeRobotBuzzer(&payload, &copy);
+    REM_RobotBuzzerPayload payload;
+    encodeREM_RobotBuzzer(&payload, &copy);
 
     BasestationMessage message;
-    message.payloadSize = PACKET_SIZE_ROBOT_BUZZER;
+    message.payloadSize = PACKET_SIZE_REM_ROBOT_BUZZER;
     std::memcpy(message.payloadBuffer, payload.payload, message.payloadSize);
 
     return this->basestationCollection->sendMessageToBasestation(message, color);
 }
 
 bool BasestationManager::sendBasestationStatisticsRequest(utils::TeamColor color) const {
-    BasestationGetStatistics command;
+    REM_BasestationGetStatistics command;
 
-    BasestationGetStatisticsPayload payload;
-    encodeBasestationGetStatistics(&payload, &command);
+    REM_BasestationGetStatisticsPayload payload;
+    encodeREM_BasestationGetStatistics(&payload, &command);
 
     BasestationMessage message;
-    message.payloadSize = PACKET_SIZE_BASESTATION_GET_STATISTICS;
+    message.payloadSize = PACKET_SIZE_REM_BASESTATION_GET_STATISTICS;
     std::memcpy(message.payloadBuffer, &payload.payload, message.payloadSize);
 
     return this->basestationCollection->sendMessageToBasestation(message, color);
 }
 
-void BasestationManager::setFeedbackCallback(const std::function<void(const RobotFeedback&, utils::TeamColor)>& callback) { this->feedbackCallbackFunction = callback; }
+void BasestationManager::setFeedbackCallback(const std::function<void(const REM_RobotFeedback&, utils::TeamColor)>& callback) { this->feedbackCallbackFunction = callback; }
 
 void BasestationManager::listenForBasestationPlugs() {
     while (this->shouldListenForBasestationPlugs) {
@@ -107,12 +107,12 @@ std::vector<libusb_device*> BasestationManager::filterBasestationDevices(libusb_
 
 void BasestationManager::handleIncomingMessage(const BasestationMessage& message, utils::TeamColor color) const {
     switch (message.payloadBuffer[0]) {
-        case PACKET_TYPE_ROBOT_FEEDBACK: {
-            RobotFeedbackPayload payload;
+        case PACKET_TYPE_REM_ROBOT_FEEDBACK: {
+            REM_RobotFeedbackPayload payload;
             std::memcpy(payload.payload, message.payloadBuffer, message.payloadSize);
 
-            RobotFeedback feedback;
-            decodeRobotFeedback(&feedback, &payload);
+            REM_RobotFeedback feedback;
+            decodeREM_RobotFeedback(&feedback, &payload);
 
             this->callFeedbackCallback(feedback, color);
             break;
@@ -120,7 +120,7 @@ void BasestationManager::handleIncomingMessage(const BasestationMessage& message
     }
 }
 
-void BasestationManager::callFeedbackCallback(const RobotFeedback& feedback, utils::TeamColor color) const {
+void BasestationManager::callFeedbackCallback(const REM_RobotFeedback& feedback, utils::TeamColor color) const {
     if (this->feedbackCallbackFunction != nullptr) this->feedbackCallbackFunction(feedback, color);
 }
 


### PR DESCRIPTION
So, [REM has a PR](https://github.com/RoboTeamTwente/roboteam_embedded_messages/pull/8) that changes the names of the generated datatypes. This PR follows these name changes.
That does mean that this PR is dependent on that other PR!