### PR TITLE
Increase default batterylevel of robot feedback

### DIFF
--- a/src/RobotHub.cpp
+++ b/src/RobotHub.cpp
@@ -242,7 +242,7 @@ void RobotHub::handleRobotFeedbackFromSimulator(const simulation::RobotControlFe
             .capacitorIsCharged = true,
             .wheelLocked = 0,
             .wheelBraking = 0,
-            .batteryLevel = 0,
+            .batteryLevel = 23.0f,
             .signalStrength = 0
         };
         robotsFeedback.feedback.push_back(robotFeedback);


### PR DESCRIPTION
Increase default value of the battery level of robots in the simulator. It really does not matter what value this is, but if it is too low, the interface of AI will complain, hence this small PR