### PR TITLE
Fix/update rem

### DIFF
--- a/include/basestation/BasestationManager.hpp
+++ b/include/basestation/BasestationManager.hpp
@@ -26,7 +26,6 @@ class BasestationManager {
 
     int sendRobotCommand(const REM_RobotCommand &command, rtt::Team color) const;
     int sendRobotBuzzerCommand(const REM_RobotBuzzer &command, rtt::Team color) const;
-    int sendBasestationStatisticsRequest(rtt::Team color) const;
 
     void setFeedbackCallback(const std::function<void(const REM_RobotFeedback &, rtt::Team color)> &callback);
 

--- a/src/basestation/BasestationManager.cpp
+++ b/src/basestation/BasestationManager.cpp
@@ -1,5 +1,3 @@
-#include <REM_BasestationGetStatistics.h>
-
 #include <basestation/BasestationManager.hpp>
 #include <cstring>
 
@@ -56,20 +54,6 @@ int BasestationManager::sendRobotBuzzerCommand(const REM_RobotBuzzer& command, r
     BasestationMessage message;
     message.payloadSize = PACKET_SIZE_REM_ROBOT_BUZZER;
     std::memcpy(message.payloadBuffer, payload.payload, message.payloadSize);
-
-    int bytesSent = this->basestationCollection->sendMessageToBasestation(message, color);
-    return bytesSent;
-}
-
-int BasestationManager::sendBasestationStatisticsRequest(rtt::Team color) const {
-    REM_BasestationGetStatistics command;
-
-    REM_BasestationGetStatisticsPayload payload;
-    encodeREM_BasestationGetStatistics(&payload, &command);
-
-    BasestationMessage message;
-    message.payloadSize = PACKET_SIZE_REM_BASESTATION_GET_STATISTICS;
-    std::memcpy(message.payloadBuffer, &payload.payload, message.payloadSize);
 
     int bytesSent = this->basestationCollection->sendMessageToBasestation(message, color);
     return bytesSent;


### PR DESCRIPTION
REM got updated, and a packet type got removed that was already implemented in robothub. This PR removes this implementation from robothub, so it compiles again