### PR TITLE
Feature/return bytes sent

### DIFF
--- a/src/RobotHub.cpp
+++ b/src/RobotHub.cpp
@@ -300,8 +300,7 @@ void RobotHub::handleRobotFeedbackFromBasestation(const REM_RobotFeedback &feedb
 
 bool RobotHub::sendRobotFeedback(const rtt::RobotsFeedback &feedback) {
     auto bytesSent = this->robotFeedbackPublisher->publish(feedback);
-    if (bytesSent > 0) this->statistics.feedbackBytesSent += bytesSent;
-
+    this->statistics.feedbackBytesSent += bytesSent;
     return bytesSent > 0;
 }
 

--- a/src/RobotHub.cpp
+++ b/src/RobotHub.cpp
@@ -299,9 +299,10 @@ void RobotHub::handleRobotFeedbackFromBasestation(const REM_RobotFeedback &feedb
 }
 
 bool RobotHub::sendRobotFeedback(const rtt::RobotsFeedback &feedback) {
-    this->statistics.feedbackBytesSent += static_cast<int>(sizeof(feedback));
+    auto bytesSent = this->robotFeedbackPublisher->publish(feedback);
+    if (bytesSent > 0) this->statistics.feedbackBytesSent += bytesSent;
 
-    return this->robotFeedbackPublisher->publish(feedback);
+    return bytesSent > 0;
 }
 
 void RobotHub::handleRobotStateInfo(const REM_RobotStateInfo& info, rtt::Team team) {

--- a/src/RobotHub.cpp
+++ b/src/RobotHub.cpp
@@ -267,6 +267,7 @@ void RobotHub::handleRobotFeedbackFromSimulator(const simulation::RobotControlFe
     }
 
     this->sendRobotFeedback(robotsFeedback);
+    this->logRobotFeedback(robotsFeedback);
 }
 
 void RobotHub::handleRobotFeedbackFromBasestation(const REM_RobotFeedback &feedback, rtt::Team basestationColor) {
@@ -294,12 +295,11 @@ void RobotHub::handleRobotFeedbackFromBasestation(const REM_RobotFeedback &feedb
 
     // Increment the feedback counter of this robot
     this->statistics.incrementFeedbackReceivedCounter(feedback.id, basestationColor);
+    this->logRobotFeedback(robotsFeedback);
 }
 
 bool RobotHub::sendRobotFeedback(const rtt::RobotsFeedback &feedback) {
     this->statistics.feedbackBytesSent += static_cast<int>(sizeof(feedback));
-
-    this->logRobotFeedback(feedback);
 
     return this->robotFeedbackPublisher->publish(feedback);
 }


### PR DESCRIPTION
First of all, the bytes sent of the feedback was incorrectly calculated, as it did not calculate the size of the vector data. Second of all, it did not take into account the compression that is done by protobuf. This PR uses the new return type of the publish function that returns the actual amount of bytes sent.
Therefore, this PR is co-dependent on:
- The [PR in networking](https://github.com/RoboTeamTwente/roboteam_networking/pull/13)
- The [PR in AI](https://github.com/RoboTeamTwente/roboteam_ai/pull/1399)
- The [PR in World](https://github.com/RoboTeamTwente/roboteam_world/pull/80)