### PR TITLE
Feature/marple logging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ target_link_libraries(basestation_manager PUBLIC
 target_compile_options(basestation_manager PRIVATE "${COMPILER_FLAGS}")
 
 # Create the make file for RobotHub, which uses the basestationManager and simulationManager library
-add_executable(roboteam_robothub "src/RobotHubStatistics.cpp" "src/RobotHub.cpp")
+add_executable(roboteam_robothub "src/RobotHubStatistics.cpp" "src/RobotHubLogger.cpp" "src/RobotHub.cpp")
 target_include_directories(roboteam_robothub
         PRIVATE include
 )

--- a/include/RobotHub.h
+++ b/include/RobotHub.h
@@ -2,6 +2,7 @@
 
 #include <libusb-1.0/libusb.h>
 
+#include <RobotHubLogger.hpp>
 #include <RobotCommandsNetworker.hpp>
 #include <RobotFeedbackNetworker.hpp>
 #include <RobotHubStatistics.hpp>
@@ -12,6 +13,7 @@
 #include <exception>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <roboteam_utils/RobotCommands.hpp>
 #include <roboteam_utils/RobotFeedback.hpp>
 #include <roboteam_utils/Teams.hpp>
@@ -22,17 +24,13 @@ namespace rtt::robothub {
 
 class RobotHub {
    public:
-    explicit RobotHub(bool shouldLog);
+    explicit RobotHub(bool shouldLog, bool logInMarpleFormat = false);
 
     const RobotHubStatistics &getStatistics();
     void resetStatistics();
 
    private:
-    std::thread loggerThread;
-
-    std::unique_ptr<FileLogger> robotStateLogger;
-    std::unique_ptr<FileLogger> robotCommandLogger;
-    std::unique_ptr<FileLogger> robotFeedbackLogger;
+    std::optional<RobotHubLogger> logger;
 
     std::unique_ptr<simulation::SimulatorManager> simulatorManager;
     std::unique_ptr<basestation::BasestationManager> basestationManager;
@@ -71,10 +69,6 @@ class RobotHub {
     void handleBasestationLog(const std::string& basestationLogMessage, rtt::Team team);
 
     void handleSimulationErrors(const std::vector<simulation::SimulationError>&);
-
-    void logRobotStateInfo(const REM_RobotStateInfo& robotStateInfo, rtt::Team team);
-    void logRobotCommands(const rtt::RobotCommands& commands, rtt::Team team);
-    void logRobotFeedback(const rtt::RobotsFeedback& feedback);
 };
 
 class FailedToInitializeNetworkersException : public std::exception {

--- a/include/RobotHubLogger.hpp
+++ b/include/RobotHubLogger.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <fstream>
+#include <mutex>
+#include <roboteam_utils/RobotCommands.hpp>
+#include <roboteam_utils/RobotFeedback.hpp>
+#include <REM_RobotStateInfo.h>
+
+namespace rtt {
+
+// This class is meant to contain all the logging functionality of RobotHub
+class RobotHubLogger {
+public:
+    // Marple format is csv format. False for "human readable"
+    explicit RobotHubLogger(bool logInMarpleFormat);
+    ~RobotHubLogger();
+
+    void logRobotCommands(const RobotCommands&, Team);
+    void logRobotFeedback(const RobotsFeedback&);
+    void logRobotStateInfo(const REM_RobotStateInfo&, Team);
+
+private:
+    bool logInMarpleFormat;
+
+    std::ofstream commandsLogger;
+    std::ofstream feedbackLogger;
+    std::ofstream stateInfoLogger;
+};
+
+} // namespace rtt

--- a/include/RobotHubLogger.hpp
+++ b/include/RobotHubLogger.hpp
@@ -8,10 +8,10 @@
 
 namespace rtt {
 
-// This class is meant to contain all the logging functionality of RobotHub
+// This class is meant to contain all the thread-safe logging functionality of RobotHub
 class RobotHubLogger {
 public:
-    // Marple format is csv format. False for "human readable"
+    // Marple format is csv format. False for "human readable" text file
     explicit RobotHubLogger(bool logInMarpleFormat);
     ~RobotHubLogger();
 
@@ -21,6 +21,10 @@ public:
 
 private:
     bool logInMarpleFormat;
+
+    std::mutex commandsLogMutex;
+    std::mutex feedbackLogMutex;
+    std::mutex stateInfoLogMutex;
 
     std::ofstream commandsLogger;
     std::ofstream feedbackLogger;

--- a/include/RobotHubLogger.hpp
+++ b/include/RobotHubLogger.hpp
@@ -11,13 +11,19 @@ namespace rtt {
 // This class is meant to contain all the thread-safe logging functionality of RobotHub
 class RobotHubLogger {
 public:
-    // Marple format is csv format. False for "human readable" text file
+    // Marple format is csv format. False for "human-readable" text file
+    // Only moving is allowed
     explicit RobotHubLogger(bool logInMarpleFormat);
+    RobotHubLogger(const RobotHubLogger& other) = delete;
+    RobotHubLogger(RobotHubLogger&& other) noexcept;
+    RobotHubLogger& operator=(const RobotHubLogger& other) = delete;
+    RobotHubLogger& operator=(RobotHubLogger&& other) noexcept;
     ~RobotHubLogger();
 
     void logRobotCommands(const RobotCommands&, Team);
     void logRobotFeedback(const RobotsFeedback&);
     void logRobotStateInfo(const REM_RobotStateInfo&, Team);
+    void logInfo(const std::string& errorMessage);
 
 private:
     bool logInMarpleFormat;
@@ -25,10 +31,12 @@ private:
     std::mutex commandsLogMutex;
     std::mutex feedbackLogMutex;
     std::mutex stateInfoLogMutex;
+    std::mutex infoMutex;
 
     std::ofstream commandsLogger;
     std::ofstream feedbackLogger;
     std::ofstream stateInfoLogger;
+    std::ofstream infoLogger;
 };
 
 } // namespace rtt

--- a/src/RobotHub.cpp
+++ b/src/RobotHub.cpp
@@ -2,7 +2,7 @@
 #include <RobotHub.h>
 #include <roboteam_utils/Print.h>
 #include <roboteam_utils/Time.h>
-#include <roboteam_utils/Format.hpp>
+
 
 #include <cmath>
 
@@ -19,7 +19,9 @@ constexpr int DEFAULT_GRSIM_FEEDBACK_PORT_CONFIGURATION = 30013;
 constexpr float SIM_CHIPPER_ANGLE_DEGREES = 45.0f;     // The angle at which the chipper shoots
 constexpr float SIM_MAX_DRIBBLER_SPEED_RPM = 1021.0f;  // The theoretical maximum speed of the dribblers
 
-RobotHub::RobotHub(bool shouldLog) {
+
+
+RobotHub::RobotHub(bool shouldLog, bool logInMarpleFormat) {
     simulation::SimulatorNetworkConfiguration config = {.blueFeedbackPort = DEFAULT_GRSIM_FEEDBACK_PORT_BLUE_CONTROL,
                                                         .yellowFeedbackPort = DEFAULT_GRSIM_FEEDBACK_PORT_YELLOW_CONTROL,
                                                         .configurationFeedbackPort = DEFAULT_GRSIM_FEEDBACK_PORT_CONFIGURATION};
@@ -39,11 +41,6 @@ RobotHub::RobotHub(bool shouldLog) {
     this->basestationManager->setRobotStateInfoCallback([&](const REM_RobotStateInfo& robotStateInfo, rtt::Team color) { this->handleRobotStateInfo(robotStateInfo, color); });
     this->basestationManager->setBasestationLogCallback([&](const std::string& log, rtt::Team color) { this->handleBasestationLog(log, color); });
 
-    if (shouldLog) {
-        this->robotStateLogger = std::make_unique<FileLogger>(Time::getDate('-') + "_" + Time::getTime('-') + "_ROBOTSTATES.txt");
-        this->robotCommandLogger = std::make_unique<FileLogger>(Time::getDate('-') + "_" + Time::getTime('-') + "_ROBOTCOMMANDS.txt");
-        this->robotFeedbackLogger = std::make_unique<FileLogger>(Time::getDate('-') + "_" + Time::getTime('-') + "_ROBOTFEEDBACK.txt");
-    }
 }
 
 const RobotHubStatistics &RobotHub::getStatistics() {
@@ -187,7 +184,7 @@ void RobotHub::onRobotCommands(const rtt::RobotCommands &commands, rtt::Team col
             break;
     }
 
-    this->logRobotCommands(commands, color);
+    if (this->logger.has_value()) { this->logger.value().logRobotCommands(commands, color); }
 }
 
 void RobotHub::onSettings(const proto::Setting &_settings) {
@@ -269,7 +266,8 @@ void RobotHub::handleRobotFeedbackFromSimulator(const simulation::RobotControlFe
 
     this->sendRobotFeedback(robotsFeedback);
     this->handleSimulationErrors(feedback.simulationErrors);
-    this->logRobotFeedback(robotsFeedback);
+
+    if (this->logger.has_value()) { this->logger->logRobotFeedback(robotsFeedback); }
 }
 
 void RobotHub::handleRobotFeedbackFromBasestation(const REM_RobotFeedback &feedback, rtt::Team basestationColor) {
@@ -297,7 +295,8 @@ void RobotHub::handleRobotFeedbackFromBasestation(const REM_RobotFeedback &feedb
 
     // Increment the feedback counter of this robot
     this->statistics.incrementFeedbackReceivedCounter(feedback.id, basestationColor);
-    this->logRobotFeedback(robotsFeedback);
+
+    if (this->logger.has_value()) { this->logger->logRobotFeedback(robotsFeedback); }
 }
 
 bool RobotHub::sendRobotFeedback(const rtt::RobotsFeedback &feedback) {
@@ -311,7 +310,7 @@ void RobotHub::handleSimulationConfigurationFeedback(const simulation::Configura
 }
 
 void RobotHub::handleRobotStateInfo(const REM_RobotStateInfo& info, rtt::Team team) {
-    this->logRobotStateInfo(info, team);
+    if (this->logger.has_value()) { this->logger->logRobotStateInfo(info, team); }
 }
 
 void RobotHub::handleBasestationLog(const std::string &basestationLogMessage, rtt::Team team) {
@@ -331,61 +330,16 @@ void RobotHub::handleSimulationErrors(const std::vector<simulation::SimulationEr
     }
 }
 
-void RobotHub::logRobotStateInfo(const REM_RobotStateInfo &info, rtt::Team team) {
-    if (this->robotStateLogger == nullptr) return;
-
-    std::stringstream ss;
-    ss << "[" << Time::getTimeWithMilliseconds(':') << "] "
-       << "Team: " << teamToString(team)
-       << "Id: " << formatString("%2i", info.id) << ", "
-       << "MsgId: " << formatString("%5i", info.messageId) << ", "
-       << "xSensAcc1: " << formatString("%7f", info.xsensAcc1) << ", "
-       << "xSensAcc2: " << formatString("%7f", info.xsensAcc2) << ", "
-       << "xSensYaw: " << formatString("%7f", info.xsensYaw) << ", "
-       << "rateOfTurn: " << formatString("%7f", info.rateOfTurn) << ", "
-       << "wheelSp1: " << formatString("%&7f", info.wheelSpeed1) << ", "
-       << "wheelSp2: " << formatString("%7f", info.wheelSpeed2) << ", "
-       << "wheelSp3: " << formatString("%7f", info.wheelSpeed3) << ", "
-       << "wheelSp4: " << formatString("%7f", info.wheelSpeed4) << std::endl;
-
-    this->robotStateLogger->operator<<(ss.rdbuf());
-}
-
-void RobotHub::logRobotCommands(const rtt::RobotCommands &commands, rtt::Team team) {
-    if (robotCommandLogger == nullptr) return;
-
-    std::string teamStr = teamToString(team);
-    std::string timeStr = Time::getTimeWithMilliseconds(':');
-
-    std::stringstream ss;
-    for (const auto& command : commands) {
-        ss << "[" << timeStr << ", " << teamStr << "] " << command << std::endl;
-    }
-    this->robotCommandLogger->operator<<(ss.rdbuf());
-}
-
-void RobotHub::logRobotFeedback(const rtt::RobotsFeedback &feedback) {
-    if (this->robotFeedbackLogger == nullptr) return;
-
-    std::string teamStr = teamToString(feedback.team);
-    std::string sourceStr = robotFeedbackSourceToString(feedback.source);
-    std::string timeStr = Time::getTimeWithMilliseconds(':');
-
-    std::stringstream ss;
-    for (const auto &robot : feedback.feedback) {
-        ss << "[" << timeStr << ", " << teamStr << ", " << sourceStr << "] " << robot << std::endl;
-    }
-
-    this->robotFeedbackLogger->operator<<(ss.rdbuf());
-}
-
 const char *FailedToInitializeNetworkersException::what() const noexcept { return "Failed to initialize networker(s). Is another RobotHub running?"; }
 
 }  // namespace rtt::robothub
 
 int main(int argc, char *argv[]) {
-    auto it = std::find(argv, argv + argc, std::string("-log"));
-    bool shouldLog = it != argv + argc;
+    auto itLog = std::find(argv, argv + argc, std::string("-log"));
+    bool shouldLog = itLog != argv + argc;
+
+    auto itMarple = std::find(argv, argv + argc, std::string("-marple"));
+    bool logForMarple = itMarple != argv + argc;
 
     rtt::robothub::RobotHub app(shouldLog);
 

--- a/src/RobotHub.cpp
+++ b/src/RobotHub.cpp
@@ -341,7 +341,9 @@ int main(int argc, char *argv[]) {
     auto itMarple = std::find(argv, argv + argc, std::string("-marple"));
     bool logForMarple = itMarple != argv + argc;
 
-    rtt::robothub::RobotHub app(shouldLog);
+    if (logForMarple) shouldLog = true; // Log for marple means to log
+
+    rtt::robothub::RobotHub app(shouldLog, logForMarple);
 
     while (true) {
         std::this_thread::sleep_for(std::chrono::seconds(1));

--- a/src/RobotHubLogger.cpp
+++ b/src/RobotHubLogger.cpp
@@ -21,13 +21,14 @@ RobotHubLogger::RobotHubLogger(bool logInMarpleFormat) {
     this->commandsLogger.open("COMMANDS_" + timeString + suffix);
     this->feedbackLogger.open("FEEDBACK_" + timeString + suffix);
 
+    // Check if all are successfully created
     if (!this->stateInfoLogger.is_open() || !this->commandsLogger.is_open() || !this->feedbackLogger.is_open()) {
         throw std::runtime_error("Failed to open file(s) for logging");
     }
 
     // If we log in marple format, the csv files need a header explaining the values
     if (logInMarpleFormat) {
-        // Also add std::fixed to ensure floating point notation is not scientific
+        // Also add std::fixed to ensure floating point notation is not scientific (aka human readable)
         this->stateInfoLogger << ROBOT_STATE_MARPLE_HEADER << std::fixed << std::endl;
         this->commandsLogger << ROBOT_COMMANDS_MARPLE_HEADER << std::fixed << std::endl;
         this->feedbackLogger << ROBOT_FEEDBACK_MARPLE_HEADER << std::fixed << std::endl;

--- a/src/RobotHubLogger.cpp
+++ b/src/RobotHubLogger.cpp
@@ -1,0 +1,177 @@
+#include <RobotHubLogger.hpp>
+
+#include <roboteam_utils/Time.h>
+#include <roboteam_utils/Format.hpp>
+
+constexpr char MARPLE_DELIMITER = ',';
+constexpr char ROBOT_STATE_MARPLE_HEADER[] = "time,team,xSensAcc1,xSensAcc2,xSensYaw,rateOfTurn,wheelSpeed1,wheelSpeed2,wheelSpeed3,wheelSpeed4";
+constexpr char ROBOT_COMMANDS_MARPLE_HEADER[] = "time,team,id,xVel,yVel,targetAngle,targetAngularVel,camAngle,camAngleIsSet,kickSpeed,waitForBall,kickType,dribblerSpeed,ignorePacket";
+constexpr char ROBOT_FEEDBACK_MARPLE_HEADER[] = "time,team,source,id,hasBall,ballPos,sensorWorking,velX,velY,angle,xSensCalibrated,capCharged,wheelLocked,wheelBraking,batteryLevel,signalStrength";
+
+namespace rtt {
+
+RobotHubLogger::RobotHubLogger(bool logInMarpleFormat) {
+    this->logInMarpleFormat = logInMarpleFormat;
+
+    // Create the loggers
+    auto timeString = Time::getDate('-') + "_" + Time::getTime('-');
+    auto suffix = logInMarpleFormat ? "_MARPLE.csv" : ".txt";
+
+    this->stateInfoLogger.open("ROBOTSTATES_" + timeString + suffix);
+    this->commandsLogger.open("COMMANDS_" + timeString + suffix);
+    this->feedbackLogger.open("FEEDBACK_" + timeString + suffix);
+
+    if (!this->stateInfoLogger.is_open() || !this->commandsLogger.is_open() || !this->feedbackLogger.is_open()) {
+        throw std::runtime_error("Failed to open file(s) for logging");
+    }
+
+    // If we log in marple format, the csv files need a header explaining the values
+    if (logInMarpleFormat) {
+        // Also add std::fixed to ensure floating point notation is not scientific
+        this->stateInfoLogger << ROBOT_STATE_MARPLE_HEADER << std::fixed << std::endl;
+        this->commandsLogger << ROBOT_COMMANDS_MARPLE_HEADER << std::fixed << std::endl;
+        this->feedbackLogger << ROBOT_FEEDBACK_MARPLE_HEADER << std::fixed << std::endl;
+    }
+}
+
+RobotHubLogger::~RobotHubLogger() {
+    this->stateInfoLogger.close();
+    this->commandsLogger.close();
+    this->feedbackLogger.close();
+}
+
+int kickTypeToInt(rtt::KickType type) {
+    switch (type) {
+        case rtt::KickType::NO_KICK:
+            return 0;
+        case rtt::KickType::KICK:
+            return 1;
+        case rtt::KickType::CHIP:
+            return 2;
+        default:
+            return -1;
+    }
+}
+int teamToInt(rtt::Team team) {
+    switch (team) {
+        case Team::YELLOW:
+            return 0;
+        case Team::BLUE:
+            return 1;
+        default:
+            return -1;
+    }
+}
+
+int feedbackSourceToInt(rtt::RobotFeedbackSource source) {
+    switch (source) {
+        case RobotFeedbackSource::SIMULATOR:
+            return 0;
+        case RobotFeedbackSource::BASESTATION:
+            return 1;
+        default:
+            return -1;
+    }
+}
+
+void RobotHubLogger::logRobotCommands(const RobotCommands &commands, Team team) {
+    if (this->logInMarpleFormat) {
+        for (const auto& command : commands) {
+            auto now = std::chrono::system_clock::now().time_since_epoch().count();
+            //time,team,id,xVel,yVel,targetAngle,targetAngularVel,camAngle,camAngleIsSet,kickSpeed,waitForBall,kickType,dribblerSpeed,ignorePacket
+            this->commandsLogger
+                << now << MARPLE_DELIMITER
+                << teamToInt(team) << MARPLE_DELIMITER
+                << command.id << MARPLE_DELIMITER
+                << command.velocity.x << MARPLE_DELIMITER
+                << command.velocity.y << MARPLE_DELIMITER
+                << command.targetAngle.getValue() << MARPLE_DELIMITER
+                << command.targetAngularVelocity << MARPLE_DELIMITER
+                << command.cameraAngleOfRobot.getValue() << MARPLE_DELIMITER
+                << command.cameraAngleOfRobotIsSet << MARPLE_DELIMITER
+                << command.kickSpeed << MARPLE_DELIMITER
+                << command.waitForBall << MARPLE_DELIMITER
+                << kickTypeToInt(command.kickType) << MARPLE_DELIMITER
+                << command.dribblerSpeed << MARPLE_DELIMITER
+                << command.ignorePacket << std::endl;
+        }
+    } else {
+        std::string teamStr = teamToString(team);
+        std::string timeStr = Time::getTimeWithMilliseconds(':');
+
+        for (const auto& command : commands) {
+            this->commandsLogger << "[" << timeStr << ", " << teamStr << "] " << command << std::endl;
+        }
+    }
+}
+
+void RobotHubLogger::logRobotStateInfo(const REM_RobotStateInfo &info, Team team) {
+    if (this->logInMarpleFormat) {
+        auto now = std::chrono::system_clock::now().time_since_epoch().count();
+        //time,team,xSensAcc1,xSensAcc2,xSensYaw,rateOfTurn,wheelSpeed1,wheelSpeed2,wheelSpeed3,wheelSpeed4
+        this->stateInfoLogger
+            << now << MARPLE_DELIMITER
+            << teamToInt(team) << MARPLE_DELIMITER
+            << info.xsensAcc1 << MARPLE_DELIMITER
+            << info.xsensAcc2 << MARPLE_DELIMITER
+            << info.xsensYaw << MARPLE_DELIMITER
+            << info.rateOfTurn << MARPLE_DELIMITER
+            << info.wheelSpeed1 << MARPLE_DELIMITER
+            << info.wheelSpeed2 << MARPLE_DELIMITER
+            << info.wheelSpeed3 << MARPLE_DELIMITER
+            << info.wheelSpeed4 << std::endl;
+    } else {
+        this->stateInfoLogger
+            << "[" << Time::getTimeWithMilliseconds(':') << "] "
+            << "Team: " << teamToString(team)
+            << "Id: " << formatString("%2i", info.id) << ", "
+            << "MsgId: " << formatString("%5i", info.messageId) << ", "
+            << "xSensAcc1: " << formatString("%7f", info.xsensAcc1) << ", "
+            << "xSensAcc2: " << formatString("%7f", info.xsensAcc2) << ", "
+            << "xSensYaw: " << formatString("%7f", info.xsensYaw) << ", "
+            << "rateOfTurn: " << formatString("%7f", info.rateOfTurn) << ", "
+            << "wheelSp1: " << formatString("%&7f", info.wheelSpeed1) << ", "
+            << "wheelSp2: " << formatString("%7f", info.wheelSpeed2) << ", "
+            << "wheelSp3: " << formatString("%7f", info.wheelSpeed3) << ", "
+            << "wheelSp4: " << formatString("%7f", info.wheelSpeed4) << std::endl;
+    }
+}
+
+void RobotHubLogger::logRobotFeedback(const RobotsFeedback &feedback) {
+    if (this->logInMarpleFormat) {
+        auto now = std::chrono::system_clock::now().time_since_epoch().count();
+        auto team = teamToInt(feedback.team);
+        auto source = feedbackSourceToInt(feedback.source);
+
+        for (const auto& robot : feedback.feedback) {
+            //time,team,source,id,hasBall,ballPos,sensorWorking,velX,velY,angle,xSensCalibrated,capCharged,wheelLocked,wheelBraking,batteryLevel,signalStrength
+            this->feedbackLogger
+                << now << MARPLE_DELIMITER
+                << team << MARPLE_DELIMITER
+                << source << MARPLE_DELIMITER
+                << robot.id << MARPLE_DELIMITER
+                << robot.hasBall << MARPLE_DELIMITER
+                << robot.ballPosition << MARPLE_DELIMITER
+                << robot.ballSensorIsWorking << MARPLE_DELIMITER
+                << robot.velocity.x << MARPLE_DELIMITER
+                << robot.velocity.y << MARPLE_DELIMITER
+                << robot.angle.getValue() << MARPLE_DELIMITER
+                << robot.xSensIsCalibrated << MARPLE_DELIMITER
+                << robot.capacitorIsCharged << MARPLE_DELIMITER
+                << robot.wheelLocked << MARPLE_DELIMITER
+                << robot.wheelBraking << MARPLE_DELIMITER
+                << robot.batteryLevel << MARPLE_DELIMITER
+                << robot.signalStrength << std::endl;
+        }
+    } else {
+        std::string teamStr = teamToString(feedback.team);
+        std::string sourceStr = robotFeedbackSourceToString(feedback.source);
+        std::string timeStr = Time::getTimeWithMilliseconds(':');
+
+        for (const auto &robot : feedback.feedback) {
+            this->feedbackLogger << "[" << timeStr << ", " << teamStr << ", " << sourceStr << "] " << robot << std::endl;
+        }
+    }
+}
+
+} // namespace rtt

--- a/src/RobotHubLogger.cpp
+++ b/src/RobotHubLogger.cpp
@@ -146,8 +146,8 @@ void RobotHubLogger::logRobotCommands(const RobotCommands &commands, Team team) 
     std::scoped_lock<std::mutex> lock(this->commandsLogMutex);
 
     if (this->logInMarpleFormat) {
+        auto now = std::chrono::system_clock::now().time_since_epoch().count();
         for (const auto& command : commands) {
-            auto now = std::chrono::system_clock::now().time_since_epoch().count();
             //time,team,id,xVel,yVel,targetAngle,targetAngularVel,camAngle,camAngleIsSet,kickSpeed,waitForBall,kickType,dribblerSpeed,ignorePacket
             this->commandsLogger
                 << now << MARPLE_DELIMITER

--- a/src/RobotHubLogger.cpp
+++ b/src/RobotHubLogger.cpp
@@ -75,6 +75,8 @@ int feedbackSourceToInt(rtt::RobotFeedbackSource source) {
 }
 
 void RobotHubLogger::logRobotCommands(const RobotCommands &commands, Team team) {
+    std::scoped_lock<std::mutex> lock(this->commandsLogMutex);
+
     if (this->logInMarpleFormat) {
         for (const auto& command : commands) {
             auto now = std::chrono::system_clock::now().time_since_epoch().count();
@@ -106,6 +108,7 @@ void RobotHubLogger::logRobotCommands(const RobotCommands &commands, Team team) 
 }
 
 void RobotHubLogger::logRobotStateInfo(const REM_RobotStateInfo &info, Team team) {
+    std::scoped_lock<std::mutex> lock(this->stateInfoLogMutex);
     if (this->logInMarpleFormat) {
         auto now = std::chrono::system_clock::now().time_since_epoch().count();
         //time,team,xSensAcc1,xSensAcc2,xSensYaw,rateOfTurn,wheelSpeed1,wheelSpeed2,wheelSpeed3,wheelSpeed4
@@ -138,6 +141,8 @@ void RobotHubLogger::logRobotStateInfo(const REM_RobotStateInfo &info, Team team
 }
 
 void RobotHubLogger::logRobotFeedback(const RobotsFeedback &feedback) {
+    std::scoped_lock<std::mutex> lock(this->feedbackLogMutex);
+
     if (this->logInMarpleFormat) {
         auto now = std::chrono::system_clock::now().time_since_epoch().count();
         auto team = teamToInt(feedback.team);

--- a/src/RobotHubLogger.cpp
+++ b/src/RobotHubLogger.cpp
@@ -58,6 +58,7 @@ RobotHubLogger::RobotHubLogger(RobotHubLogger &&other) noexcept {
                                       other.infoMutex);
 
     // Then swap them
+    std::swap(this->logInMarpleFormat, other.logInMarpleFormat);
     this->commandsLogger.swap(other.commandsLogger);
     this->feedbackLogger.swap(other.feedbackLogger);
     this->stateInfoLogger.swap(other.stateInfoLogger);
@@ -90,6 +91,7 @@ RobotHubLogger &RobotHubLogger::operator=(RobotHubLogger &&other) noexcept {
         this->infoLogger.close();
 
         // Then swap them
+        std::swap(this->logInMarpleFormat, other.logInMarpleFormat);
         this->commandsLogger.swap(other.commandsLogger);
         this->feedbackLogger.swap(other.feedbackLogger);
         this->stateInfoLogger.swap(other.stateInfoLogger);


### PR DESCRIPTION
This PR moves all logging funtionality to its own class to prevent cluttering of RobotHub.cpp,
and adds the possibility to log in CSV format, meant for uploading to Marple.
Pass `-marple` as program argument to start logging in the right format to a CSV file.

A [similar PR](https://github.com/RoboTeamTwente/roboteam_world/pull/81/files) has been made in world